### PR TITLE
fix(auth): Centralize JWT secret to fix repository 401 errors

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,7 +1,5 @@
 """API dependencies for authentication and common operations."""
 
-import os
-import secrets
 from typing import Optional
 
 from fastapi import HTTPException, Request, Depends
@@ -9,10 +7,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt
 
 from app.database.repositories.user import UserRepository
-
-
-JWT_SECRET = os.getenv("JWT_SECRET_KEY", secrets.token_urlsafe(32))
-JWT_ALGORITHM = "HS256"
+from app.core.config import settings
 
 security = HTTPBearer(auto_error=False)
 
@@ -48,7 +43,9 @@ def decode_token(token: str) -> dict:
         HTTPException: If token is invalid or expired.
     """
     try:
-        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        payload = jwt.decode(
+            token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
+        )
         return payload
     except JWTError as e:
         raise HTTPException(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,17 +1,28 @@
 """Application settings and configuration"""
 
+import secrets
 from pydantic_settings import BaseSettings
 from typing import List
 
 
+_DEFAULT_JWT_SECRET = secrets.token_urlsafe(32)
+
+
 class Settings(BaseSettings):
-    """Application settings loaded from environment variables"""
+    """Application settings loaded from environment variables
+
+    Security Note: JWT_SECRET_KEY MUST be set via environment variable in production.
+    The default random value is only for development convenience.
+    """
 
     APP_NAME: str = "Somm.dev API"
     API_V1_STR: str = "/api/v1"
 
-    # Environment
     ENVIRONMENT: str = "development"
+
+    JWT_SECRET_KEY: str = _DEFAULT_JWT_SECRET
+    JWT_ALGORITHM: str = "HS256"
+    JWT_EXPIRATION_DAYS: int = 7
 
     # CORS settings
     FRONTEND_URL: str = "http://localhost:3000"

--- a/backend/tests/test_deps.py
+++ b/backend/tests/test_deps.py
@@ -23,10 +23,12 @@ class TestDecodeToken:
 
     def test_decode_valid_token(self):
         """Test decoding a valid JWT token."""
-        from app.api.deps import JWT_SECRET, JWT_ALGORITHM
+        from app.core.config import settings
 
         payload = {"sub": "user123", "github_id": "456"}
-        token = jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+        token = jwt.encode(
+            payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM
+        )
 
         decoded = decode_token(token)
 


### PR DESCRIPTION
## Summary
- Centralize JWT configuration in `config.py` (single source of truth)
- Update `auth.py` and `deps.py` to use `settings.JWT_SECRET_KEY`
- Fix test that was importing removed constants

## Problem
`/auth/me` returned 200 but `/repositories` returned 401 with the same token.

**Root Cause:**
```python
# auth.py (line 30) - generated Secret A
JWT_SECRET = os.getenv("JWT_SECRET_KEY", secrets.token_urlsafe(32))

# deps.py (line 14) - generated Secret B (DIFFERENT!)
JWT_SECRET = os.getenv("JWT_SECRET_KEY", secrets.token_urlsafe(32))
```

When `JWT_SECRET_KEY` env var is not set, each file generates its own random secret at import time. Tokens created by `auth.py` couldn't be verified by `deps.py`.

## Solution
Single source of truth in `config.py`:
```python
_DEFAULT_JWT_SECRET = secrets.token_urlsafe(32)  # Generated ONCE

class Settings:
    JWT_SECRET_KEY: str = _DEFAULT_JWT_SECRET
    JWT_ALGORITHM: str = "HS256"
    JWT_EXPIRATION_DAYS: int = 7
```

## Changes
| File | Change |
|------|--------|
| `backend/app/core/config.py` | Add JWT settings |
| `backend/app/api/routes/auth.py` | Use `settings.JWT_*` |
| `backend/app/api/deps.py` | Use `settings.JWT_*` |
| `backend/tests/test_deps.py` | Import from `settings` |

## Testing
- [x] All 348 backend tests pass
- [x] LSP diagnostics clean

Fixes #55