### PR TITLE
[Phase 3] Multi-model + BYOK support

### DIFF
--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -77,11 +77,15 @@ class TestPerNodeModelConfig:
 
 
 class TestBYOKFallback:
-    def test_invalid_byok_uses_server_key(self):
+    @patch("app.providers.llm.ChatGoogleGenerativeAI")
+    def test_invalid_byok_uses_server_key(self, mock_chat_google):
         with patch("app.providers.llm.settings") as mock_settings:
             mock_settings.GEMINI_API_KEY = "server-side-key"
-            llm = build_llm("gemini", "   ", None, 0.3, 128)
-            assert isinstance(llm, ChatGoogleGenerativeAI)
+            build_llm("gemini", "   ", None, 0.3, 128)
+            mock_chat_google.assert_called_once()
+            assert (
+                mock_chat_google.call_args.kwargs["google_api_key"] == "server-side-key"
+            )
 
     def test_model_fallback_enabled(self):
         llm = build_llm(


### PR DESCRIPTION
## Summary
- Add `LLMProvider` Protocol to document the provider interface contract
- Add `BYOKValidationError` class with structured error handling (error_code, message, provider)
- Update `resolve_byok()` to return structured validation errors
- Add `with_fallbacks()` support to `build_llm()` for model-level fallback
- Add `PROVIDER_DEFAULTS` constant for default model names per provider
- Add comprehensive unit tests (15 test cases)

## Changes
| File | Change |
|------|--------|
| `backend/app/providers/llm.py` | Add Protocol, BYOKValidationError, structured errors, fallback support |
| `backend/tests/test_llm_provider.py` | Expand tests to 15 cases covering all requirements |

## Test Coverage
| Category | Tests |
|----------|-------|
| **Provider Selection Routing** | gemini, openai, anthropic, default, case-insensitive |
| **Per-Node Model Config** | custom model, custom temperature, default model |
| **BYOK Validation** | none key, valid key, empty key, error serialization |
| **Model Fallback** | fallback enabled, fallback not added for default |

## Verification
```bash
cd backend && python -m pytest tests/test_llm_provider.py -v
# 15 passed
```

## Acceptance Criteria
- [x] Providers can be swapped without changing node logic
- [x] BYOK inputs are validated and return structured errors
- [x] Existing single-provider flow stays functional
- [x] Default provider remains Gemini when BYOK absent

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * LLM 제공업체에 대한 폴백 메커니즘 추가
  * 여러 제공업체(Gemini, OpenAI, Anthropic) 지원 개선
  * BYOK(사용자 제공 API 키) 검증 강화

* **버그 수정**
  * 잘못된 API 키에 대한 오류 처리 개선
  * 공백 또는 빈 키에 대한 명확한 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->