### PR TITLE
test: trajectory tests + failure-path QA

### DIFF
--- a/backend/tests/mocks/__init__.py
+++ b/backend/tests/mocks/__init__.py
@@ -1,0 +1,17 @@
+"""Mock providers for deterministic testing."""
+
+from tests.mocks.providers import (
+    MockLLM,
+    MockLLMWithError,
+    MockLLMWithTimeout,
+    create_mock_sommelier_response,
+    MOCK_SOMMELIER_OUTPUT,
+)
+
+__all__ = [
+    "MockLLM",
+    "MockLLMWithError",
+    "MockLLMWithTimeout",
+    "create_mock_sommelier_response",
+    "MOCK_SOMMELIER_OUTPUT",
+]

--- a/backend/tests/mocks/providers.py
+++ b/backend/tests/mocks/providers.py
@@ -1,0 +1,124 @@
+import asyncio
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+from langchain_core.messages import AIMessage
+
+MOCK_SOMMELIER_OUTPUT = {
+    "sommelier_name": "mock_sommelier",
+    "score": 85,
+    "confidence": 0.9,
+    "notes": "A well-structured repository with clear organization.",
+    "summary": "Good overall quality.",
+    "recommendations": ["Add more tests", "Improve documentation"],
+    "aspects": {
+        "code_quality": 85,
+        "documentation": 80,
+        "testing": 75,
+    },
+    "techniques_used": ["static_analysis", "metric_extraction"],
+}
+
+
+def create_mock_sommelier_response(
+    sommelier_name: str = "mock",
+    score: int = 85,
+    confidence: float = 0.9,
+) -> str:
+    import json
+
+    output = {
+        "sommelier_name": sommelier_name,
+        "score": score,
+        "confidence": confidence,
+        "notes": f"Evaluation by {sommelier_name}",
+        "summary": "Test evaluation",
+        "recommendations": [],
+        "aspects": {},
+        "techniques_used": [],
+    }
+    return json.dumps(output)
+
+
+class MockLLM:
+    def __init__(
+        self,
+        response: Optional[str] = None,
+        sommelier_name: str = "mock",
+        delay: float = 0.0,
+    ):
+        self.response = response or create_mock_sommelier_response(sommelier_name)
+        self.delay = delay
+        self.call_count = 0
+        self.last_messages: List[Any] = []
+
+    async def ainvoke(
+        self, messages: List[Any], config: Optional[Dict] = None
+    ) -> AIMessage:
+        self.call_count += 1
+        self.last_messages = messages
+
+        if self.delay > 0:
+            await asyncio.sleep(self.delay)
+
+        return AIMessage(
+            content=self.response,
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+
+    def invoke(self, messages: List[Any], config: Optional[Dict] = None) -> AIMessage:
+        self.call_count += 1
+        self.last_messages = messages
+        return AIMessage(
+            content=self.response,
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+
+
+class MockLLMWithError(MockLLM):
+    def __init__(
+        self, error_message: str = "LLM API error", error_type: type = Exception
+    ):
+        super().__init__()
+        self.error_message = error_message
+        self.error_type = error_type
+
+    async def ainvoke(
+        self, messages: List[Any], config: Optional[Dict] = None
+    ) -> AIMessage:
+        self.call_count += 1
+        self.last_messages = messages
+        raise self.error_type(self.error_message)
+
+    def invoke(self, messages: List[Any], config: Optional[Dict] = None) -> AIMessage:
+        self.call_count += 1
+        self.last_messages = messages
+        raise self.error_type(self.error_message)
+
+
+class MockLLMWithTimeout(MockLLM):
+    def __init__(self, timeout_seconds: float = 30.0):
+        super().__init__()
+        self.timeout_seconds = timeout_seconds
+
+    async def ainvoke(
+        self, messages: List[Any], config: Optional[Dict] = None
+    ) -> AIMessage:
+        self.call_count += 1
+        self.last_messages = messages
+        await asyncio.sleep(self.timeout_seconds)
+        raise asyncio.TimeoutError(f"LLM call timed out after {self.timeout_seconds}s")
+
+
+def create_mock_checkpointer():
+    from langgraph.checkpoint.base import BaseCheckpointSaver
+
+    mock = MagicMock(spec=BaseCheckpointSaver)
+    return mock

--- a/backend/tests/test_failure_paths.py
+++ b/backend/tests/test_failure_paths.py
@@ -1,0 +1,204 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from tests.mocks.providers import (
+    MockLLM,
+    MockLLMWithError,
+    MockLLMWithTimeout,
+    create_mock_sommelier_response,
+)
+
+
+class TestLLMErrorHandling:
+    @pytest.mark.asyncio
+    async def test_sommelier_node_handles_llm_error_gracefully(self):
+        from app.graph.nodes.marcel import MarcelNode
+
+        node = MarcelNode()
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {"readme": "Test README"},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        mock_llm = MockLLMWithError(error_message="API rate limit exceeded")
+
+        with patch("app.graph.nodes.base.build_llm", return_value=mock_llm):
+            result = await node.evaluate(state)
+
+            assert "errors" in result
+            assert any("marcel evaluation failed" in err for err in result["errors"])
+            assert result["marcel_result"] is None
+            assert "completed_sommeliers" in result
+            assert "marcel" in result["completed_sommeliers"]
+
+    @pytest.mark.asyncio
+    async def test_sommelier_node_handles_parse_error_gracefully(self):
+        from app.graph.nodes.marcel import MarcelNode
+
+        node = MarcelNode()
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {"readme": "Test README"},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        mock_llm = MockLLM(response="invalid json response")
+
+        with patch("app.graph.nodes.base.build_llm", return_value=mock_llm):
+            result = await node.evaluate(state)
+
+            assert "errors" in result
+            assert result["marcel_result"] is None
+
+
+class TestMissingInputHandling:
+    @pytest.mark.asyncio
+    async def test_sommelier_handles_empty_repo_context(self):
+        from app.graph.nodes.marcel import MarcelNode
+
+        node = MarcelNode()
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        mock_llm = MockLLM(sommelier_name="marcel")
+
+        with patch("app.graph.nodes.base.build_llm", return_value=mock_llm):
+            result = await node.evaluate(state)
+
+            assert "completed_sommeliers" in result
+
+    @pytest.mark.asyncio
+    async def test_rag_enrich_handles_empty_context(self):
+        from app.graph.nodes.rag_enrich import rag_enrich
+
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        result = await rag_enrich(state)
+
+        assert "rag_context" in result
+        assert result["rag_context"]["chunks"] == []
+        assert result["rag_context"]["error"] is None
+
+
+class TestRAGFailureHandling:
+    @pytest.mark.asyncio
+    async def test_rag_failure_does_not_block_evaluation(self):
+        from app.graph.nodes.rag_enrich import rag_enrich
+
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {"readme": "Test content"},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        with patch("app.graph.nodes.rag_enrich._get_embeddings") as mock_embed:
+            mock_embed.side_effect = Exception("Embedding API unavailable")
+
+            result = await rag_enrich(state)
+
+            assert "rag_context" in result
+            assert result["rag_context"]["chunks"] == []
+            assert "Embedding API unavailable" in result["rag_context"]["error"]
+            assert "errors" in result
+
+    @pytest.mark.asyncio
+    async def test_rag_returns_cached_context_if_exists(self):
+        from app.graph.nodes.rag_enrich import rag_enrich
+
+        existing_context = {
+            "query": "cached query",
+            "chunks": [{"text": "cached", "source": "readme"}],
+            "error": None,
+        }
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+            "rag_context": existing_context,
+        }
+
+        result = await rag_enrich(state)
+
+        assert result["rag_context"] == existing_context
+
+
+class TestProviderFallback:
+    def test_build_llm_with_invalid_provider_raises_error(self):
+        from app.providers.llm import build_llm
+
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            build_llm(
+                provider="invalid_provider",
+                api_key=None,
+                model=None,
+                temperature=None,
+                max_output_tokens=None,
+            )
+
+    def test_byok_validation_rejects_empty_key(self):
+        from app.providers.llm import resolve_byok
+
+        resolved, error = resolve_byok("   ", "gemini")
+
+        assert resolved is None
+        assert error is not None
+        assert error.error_code == "invalid_api_key"
+
+
+class TestRetryPolicy:
+    @pytest.mark.asyncio
+    async def test_sommelier_records_timing_on_success(self):
+        from app.graph.nodes.marcel import MarcelNode
+
+        node = MarcelNode()
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {"readme": "Test README"},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        mock_llm = MockLLM(sommelier_name="marcel")
+
+        with patch("app.graph.nodes.base.build_llm", return_value=mock_llm):
+            result = await node.evaluate(state)
+
+            assert "trace_metadata" in result
+            assert "marcel" in result["trace_metadata"]
+            assert "started_at" in result["trace_metadata"]["marcel"]
+            assert "completed_at" in result["trace_metadata"]["marcel"]
+
+    @pytest.mark.asyncio
+    async def test_sommelier_records_timing_on_failure(self):
+        from app.graph.nodes.marcel import MarcelNode
+
+        node = MarcelNode()
+        state = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {"readme": "Test README"},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        mock_llm = MockLLMWithError(error_message="Timeout")
+
+        with patch("app.graph.nodes.base.build_llm", return_value=mock_llm):
+            result = await node.evaluate(state)
+
+            assert "trace_metadata" in result
+            assert "marcel" in result["trace_metadata"]
+            assert result["trace_metadata"]["marcel"]["completed_at"] is not None

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,0 +1,191 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from tests.mocks.providers import (
+    MockLLM,
+    create_mock_checkpointer,
+    create_mock_sommelier_response,
+)
+
+
+class TestEndToEndSmoke:
+    def test_graph_can_be_created_with_rag_enabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = True
+
+                graph = create_evaluation_graph()
+
+                assert graph is not None
+                assert hasattr(graph, "invoke")
+                assert hasattr(graph, "ainvoke")
+
+    def test_graph_can_be_created_with_rag_disabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+
+                assert graph is not None
+                assert hasattr(graph, "invoke")
+                assert hasattr(graph, "ainvoke")
+
+    def test_graph_has_expected_node_count_rag_enabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = True
+
+                graph = create_evaluation_graph()
+                nodes = graph.nodes
+
+                assert len(nodes) == 8
+
+    def test_graph_has_expected_node_count_rag_disabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+                nodes = graph.nodes
+
+                assert len(nodes) == 7
+
+
+class TestNodeInstantiation:
+    def test_all_sommelier_nodes_can_be_instantiated(self):
+        from app.graph.nodes.marcel import MarcelNode
+        from app.graph.nodes.isabella import IsabellaNode
+        from app.graph.nodes.heinrich import HeinrichNode
+        from app.graph.nodes.sofia import SofiaNode
+        from app.graph.nodes.laurent import LaurentNode
+        from app.graph.nodes.jeanpierre import JeanPierreNode
+
+        marcel = MarcelNode()
+        isabella = IsabellaNode()
+        heinrich = HeinrichNode()
+        sofia = SofiaNode()
+        laurent = LaurentNode()
+        jeanpierre = JeanPierreNode()
+
+        assert marcel.name == "marcel"
+        assert isabella.name == "isabella"
+        assert heinrich.name == "heinrich"
+        assert sofia.name == "sofia"
+        assert laurent.name == "laurent"
+        assert jeanpierre.name == "jeanpierre"
+
+    def test_all_sommelier_nodes_have_parser(self):
+        from app.graph.nodes.marcel import MarcelNode
+        from app.graph.nodes.isabella import IsabellaNode
+        from app.graph.nodes.heinrich import HeinrichNode
+        from app.graph.nodes.sofia import SofiaNode
+        from app.graph.nodes.laurent import LaurentNode
+        from app.graph.nodes.jeanpierre import JeanPierreNode
+
+        nodes = [
+            MarcelNode(),
+            IsabellaNode(),
+            HeinrichNode(),
+            SofiaNode(),
+            LaurentNode(),
+            JeanPierreNode(),
+        ]
+
+        for node in nodes:
+            assert hasattr(node, "parser")
+            assert node.parser is not None
+
+
+class TestStateValidation:
+    def test_evaluation_state_accepts_minimal_input(self):
+        from app.graph.state import EvaluationState
+
+        state: EvaluationState = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {},
+            "evaluation_criteria": "basic",
+            "user_id": "user1",
+        }
+
+        assert state["repo_url"] == "https://github.com/test/repo"
+        assert state["evaluation_criteria"] == "basic"
+
+    def test_evaluation_state_accepts_full_input(self):
+        from app.graph.state import EvaluationState
+
+        state: EvaluationState = {
+            "repo_url": "https://github.com/test/repo",
+            "repo_context": {"readme": "Test"},
+            "evaluation_criteria": "hackathon",
+            "user_id": "user1",
+            "marcel_result": None,
+            "isabella_result": None,
+            "heinrich_result": None,
+            "sofia_result": None,
+            "laurent_result": None,
+            "jeanpierre_result": None,
+            "completed_sommeliers": [],
+            "errors": [],
+            "rag_context": None,
+            "started_at": "2024-01-01T00:00:00Z",
+            "completed_at": None,
+        }
+
+        assert state["evaluation_criteria"] == "hackathon"
+        assert state["completed_sommeliers"] == []
+
+
+class TestMockProviderSuite:
+    def test_mock_llm_returns_valid_response(self):
+        mock_llm = MockLLM(sommelier_name="test")
+
+        response = mock_llm.invoke([])
+
+        assert response.content is not None
+        assert "test" in response.content
+
+    @pytest.mark.asyncio
+    async def test_mock_llm_async_returns_valid_response(self):
+        mock_llm = MockLLM(sommelier_name="test")
+
+        response = await mock_llm.ainvoke([])
+
+        assert response.content is not None
+        assert response.usage_metadata is not None
+        assert response.usage_metadata["total_tokens"] == 150
+
+    def test_mock_llm_tracks_call_count(self):
+        mock_llm = MockLLM()
+
+        assert mock_llm.call_count == 0
+        mock_llm.invoke([])
+        assert mock_llm.call_count == 1
+        mock_llm.invoke([])
+        assert mock_llm.call_count == 2
+
+    def test_create_mock_sommelier_response_is_valid_json(self):
+        import json
+
+        response = create_mock_sommelier_response("marcel", 90, 0.95)
+
+        parsed = json.loads(response)
+        assert parsed["sommelier_name"] == "marcel"
+        assert parsed["score"] == 90
+        assert parsed["confidence"] == 0.95

--- a/backend/tests/test_trajectory.py
+++ b/backend/tests/test_trajectory.py
@@ -1,0 +1,186 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from langgraph.graph import END
+
+from tests.mocks.providers import create_mock_checkpointer
+
+
+class TestGraphTrajectory:
+    def test_trajectory_rag_disabled_fan_out(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+                builder = getattr(graph, "builder", None)
+                all_edges = builder.edges
+
+                start_edges = [e for e in all_edges if e[0] == "__start__"]
+                sommelier_targets = {e[1] for e in start_edges}
+
+                expected_sommeliers = {
+                    "marcel",
+                    "isabella",
+                    "heinrich",
+                    "sofia",
+                    "laurent",
+                }
+                assert sommelier_targets == expected_sommeliers
+                assert len(start_edges) == 5
+
+    def test_trajectory_rag_enabled_sequential_then_fan_out(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = True
+
+                graph = create_evaluation_graph()
+                builder = getattr(graph, "builder", None)
+                all_edges = builder.edges
+
+                start_edges = [e for e in all_edges if e[0] == "__start__"]
+                assert len(start_edges) == 1
+                assert start_edges[0][1] == "rag_enrich"
+
+                rag_edges = [e for e in all_edges if e[0] == "rag_enrich"]
+                rag_targets = {e[1] for e in rag_edges}
+                expected_sommeliers = {
+                    "marcel",
+                    "isabella",
+                    "heinrich",
+                    "sofia",
+                    "laurent",
+                }
+                assert rag_targets == expected_sommeliers
+
+    def test_trajectory_fan_in_to_jeanpierre(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+                builder = getattr(graph, "builder", None)
+                all_edges = builder.edges
+
+                jeanpierre_sources = [e[0] for e in all_edges if e[1] == "jeanpierre"]
+                expected_sources = {
+                    "marcel",
+                    "isabella",
+                    "heinrich",
+                    "sofia",
+                    "laurent",
+                }
+                assert set(jeanpierre_sources) == expected_sources
+
+    def test_trajectory_jeanpierre_to_end(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+                builder = getattr(graph, "builder", None)
+                all_edges = builder.edges
+
+                end_edges = [e for e in all_edges if e[1] == END]
+                assert len(end_edges) == 1
+                assert end_edges[0][0] == "jeanpierre"
+
+    def test_complete_trajectory_rag_disabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+                builder = getattr(graph, "builder", None)
+                all_edges = builder.edges
+
+                expected_edge_count = 5 + 5 + 1
+                assert len(all_edges) == expected_edge_count
+
+    def test_complete_trajectory_rag_enabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = True
+
+                graph = create_evaluation_graph()
+                builder = getattr(graph, "builder", None)
+                all_edges = builder.edges
+
+                expected_edge_count = 1 + 5 + 5 + 1
+                assert len(all_edges) == expected_edge_count
+
+
+class TestNodeExecutionOrder:
+    def test_all_sommelier_nodes_present(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+                nodes = graph.nodes
+
+                expected_nodes = [
+                    "marcel",
+                    "isabella",
+                    "heinrich",
+                    "sofia",
+                    "laurent",
+                    "jeanpierre",
+                ]
+                for node_name in expected_nodes:
+                    assert node_name in nodes
+
+    def test_rag_node_present_when_enabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = True
+
+                graph = create_evaluation_graph()
+                nodes = graph.nodes
+
+                assert "rag_enrich" in nodes
+
+    def test_rag_node_absent_when_disabled(self):
+        from app.graph.graph import create_evaluation_graph
+
+        with patch("app.graph.graph.get_checkpointer") as mock_checkpointer:
+            mock_checkpointer.return_value = create_mock_checkpointer()
+
+            with patch("app.graph.graph.settings") as mock_settings:
+                mock_settings.RAG_ENABLED = False
+
+                graph = create_evaluation_graph()
+                nodes = graph.nodes
+
+                assert "rag_enrich" not in nodes


### PR DESCRIPTION
## Summary

Implements Issue #72 - Trajectory tests and failure-path QA for the evaluation graph.

## Changes

### Mock Provider Suite (`tests/mocks/`)
- `MockLLM`: Deterministic LLM responses with call tracking
- `MockLLMWithError`: Simulates LLM API errors
- `MockLLMWithTimeout`: Simulates timeout scenarios
- `create_mock_sommelier_response()`: Generate valid JSON responses

### Trajectory Tests (`test_trajectory.py`) - 9 tests
- Fan-out pattern validation (RAG enabled/disabled)
- Fan-in to Jean-Pierre verification
- Complete trajectory edge count assertions
- Node presence/absence based on RAG config

### Failure-Path Tests (`test_failure_paths.py`) - 10 tests
- LLM error handling (graceful degradation)
- Parse error recovery
- Empty repo context handling
- RAG failure isolation
- Provider validation errors
- Timing metadata on success/failure

### Smoke Tests (`test_smoke.py`) - 12 tests
- Graph creation verification
- Node count assertions
- Sommelier instantiation
- State validation
- Mock provider functionality

## Test Coverage

```
31 tests total:
- test_trajectory.py: 9 passed
- test_failure_paths.py: 10 passed
- test_smoke.py: 12 passed
```

## Acceptance Criteria

- [x] Graph trajectories validated in CI
- [x] Failure-path tests pass and document expected behavior
- [x] Mock provider tests are deterministic

Closes #72