### PR TITLE
feat(#166): [Graph Track][GF-1] TypeScript 타입 정의 + Graph API 클라이언트

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,13 @@
-import { EvaluationResult, EvaluationHistoryItem, CriteriaType, EvaluationMode } from '../types';
+import { 
+  EvaluationResult, 
+  EvaluationHistoryItem, 
+  CriteriaType, 
+  EvaluationMode,
+  ReactFlowGraph,
+  Graph3DPayload,
+  TraceEvent,
+  ModeResponse
+} from '../types';
 
 const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.somm.dev';
 const TOKEN_STORAGE_KEY = 'somm_auth_token';
@@ -188,5 +197,23 @@ export const api = {
 
   getCurrentUser: async (token: string): Promise<User> => {
     return fetchWithConfig('/auth/me', {}, token);
+  },
+
+  getGraph: async (evaluationId: string, refresh?: boolean): Promise<ReactFlowGraph> => {
+    const queryParams = refresh ? '?refresh=true' : '';
+    return fetchWithConfig(`/api/evaluate/${evaluationId}/graph${queryParams}`);
+  },
+
+  getGraph3D: async (evaluationId: string, refresh?: boolean): Promise<Graph3DPayload> => {
+    const queryParams = refresh ? '?refresh=true' : '';
+    return fetchWithConfig(`/api/evaluate/${evaluationId}/graph-3d${queryParams}`);
+  },
+
+  getTimeline: async (evaluationId: string): Promise<TraceEvent[]> => {
+    return fetchWithConfig(`/api/evaluate/${evaluationId}/graph/timeline`);
+  },
+
+  getGraphMode: async (evaluationId: string): Promise<ModeResponse> => {
+    return fetchWithConfig(`/api/evaluate/${evaluationId}/graph/mode`);
   },
 };

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -1,0 +1,180 @@
+export const GRAPH_SCHEMA_VERSION = 2;
+
+export type GraphEvaluationMode = 'six_hats' | 'full_techniques';
+
+export type ReactFlowNodeType = 
+  | 'start' 
+  | 'end' 
+  | 'agent' 
+  | 'technique' 
+  | 'synthesis' 
+  | 'process' 
+  | 'rag';
+
+export type NodeStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface ReactFlowNodeData {
+  label: string;
+  status?: NodeStatus;
+  progress?: number;
+  color?: string;
+  hatType?: string;
+  category?: string;
+  tokenUsage?: number;
+  costUsd?: number;
+  [key: string]: unknown;
+}
+
+export interface ReactFlowNode {
+  id: string;
+  type: ReactFlowNodeType | string;
+  position: { x: number; y: number };
+  data: ReactFlowNodeData;
+}
+
+export interface ReactFlowEdge {
+  id: string;
+  source: string;
+  target: string;
+  animated?: boolean;
+  style?: Record<string, unknown>;
+}
+
+export interface ReactFlowGraph {
+  graph_schema_version: number;
+  mode: GraphEvaluationMode | string;
+  nodes: ReactFlowNode[];
+  edges: ReactFlowEdge[];
+  description?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface Position3D {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export type Graph3DEdgeType = 'flow' | 'parallel' | 'data' | 'excluded';
+
+export interface Graph3DNode {
+  node_id: string;
+  node_type: string;
+  label: string;
+  position: Position3D;
+  color?: string;
+  step_number: number;
+  hat_type?: string;
+  technique_id?: string;
+  category?: string;
+  item_count?: number;
+}
+
+export interface Graph3DEdge {
+  edge_id: string;
+  source: string;
+  target: string;
+  edge_type: Graph3DEdgeType | string;
+  color?: string;
+  width: number;
+  step_number: number;
+  bundle_id?: string;
+  bundled_path?: Position3D[];
+  dasharray?: string;
+}
+
+export interface ExcludedTechnique {
+  technique_id: string;
+  reason: string;
+}
+
+export interface Graph3DMetadata {
+  x_range: [number, number];
+  y_range: [number, number];
+  z_range: [number, number];
+  total_nodes: number;
+  total_edges: number;
+  total_steps: number;
+  max_step_number: number;
+  graph_schema_version: number;
+  generated_at: string;
+}
+
+export interface Graph3DPayload {
+  graph_schema_version: number;
+  evaluation_id: string;
+  mode: GraphEvaluationMode | string;
+  nodes: Graph3DNode[];
+  edges: Graph3DEdge[];
+  edges_raw?: Graph3DEdge[];
+  excluded_techniques?: ExcludedTechnique[];
+  metadata: Graph3DMetadata;
+}
+
+export interface TraceEvent {
+  step: number;
+  timestamp: string;
+  agent: string;
+  technique_id: string;
+  item_id?: string;
+  action: string;
+  score_delta?: number;
+  evidence_ref?: string;
+}
+
+export interface ModeResponse {
+  mode: GraphEvaluationMode | string;
+  evaluation_id: string;
+}
+
+export function isReactFlowNode(value: unknown): value is ReactFlowNode {
+  if (typeof value !== 'object' || value === null) return false;
+  const node = value as Record<string, unknown>;
+  return (
+    typeof node.id === 'string' &&
+    typeof node.type === 'string' &&
+    typeof node.position === 'object' &&
+    node.position !== null &&
+    typeof (node.position as Record<string, unknown>).x === 'number' &&
+    typeof (node.position as Record<string, unknown>).y === 'number' &&
+    typeof node.data === 'object' &&
+    node.data !== null
+  );
+}
+
+export function isReactFlowGraph(value: unknown): value is ReactFlowGraph {
+  if (typeof value !== 'object' || value === null) return false;
+  const graph = value as Record<string, unknown>;
+  return (
+    typeof graph.graph_schema_version === 'number' &&
+    typeof graph.mode === 'string' &&
+    Array.isArray(graph.nodes) &&
+    Array.isArray(graph.edges)
+  );
+}
+
+export function isGraph3DPayload(value: unknown): value is Graph3DPayload {
+  if (typeof value !== 'object' || value === null) return false;
+  const payload = value as Record<string, unknown>;
+  return (
+    typeof payload.graph_schema_version === 'number' &&
+    typeof payload.evaluation_id === 'string' &&
+    typeof payload.mode === 'string' &&
+    Array.isArray(payload.nodes) &&
+    Array.isArray(payload.edges) &&
+    typeof payload.metadata === 'object' &&
+    payload.metadata !== null
+  );
+}
+
+export function isTraceEvent(value: unknown): value is TraceEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const event = value as Record<string, unknown>;
+  return (
+    typeof event.step === 'number' &&
+    typeof event.timestamp === 'string' &&
+    typeof event.agent === 'string' &&
+    typeof event.technique_id === 'string' &&
+    typeof event.action === 'string'
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,3 +68,5 @@ export interface SommelierProgress {
   status: 'pending' | 'analyzing' | 'completed' | 'failed';
   result?: SommelierResult;
 }
+
+export * from './graph';


### PR DESCRIPTION
## Summary
Resolves #166

Graph Track Phase GF-1 구현: TypeScript 타입 정의 및 Graph API 클라이언트 확장

## Changes

### 1. 타입 정의 (`frontend/src/types/graph.ts`)
- `ReactFlowGraph`, `ReactFlowNode`, `ReactFlowEdge` - 2D 그래프 (ReactFlow 호환)
- `Graph3DPayload`, `Graph3DNode`, `Graph3DEdge`, `Graph3DMetadata` - 3D 그래프 (Three.js)
- `TraceEvent` - 타임라인 이벤트
- `ModeResponse` - 평가 모드 응답
- Type guards: `isReactFlowNode`, `isReactFlowGraph`, `isGraph3DPayload`, `isTraceEvent`

### 2. API 클라이언트 확장 (`frontend/src/lib/api.ts`)
- `api.getGraph(evaluationId, refresh?)` - 2D 그래프 조회
- `api.getGraph3D(evaluationId, refresh?)` - 3D 그래프 조회
- `api.getTimeline(evaluationId)` - 타임라인 조회
- `api.getGraphMode(evaluationId)` - 평가 모드 조회
- `?refresh=true` 쿼리 파라미터 지원

### 3. 타입 내보내기 (`frontend/src/types/index.ts`)
- graph.ts에서 모든 타입 re-export

## Testing
- [x] TypeScript 빌드 에러 없음 (`npm run build`)
- [x] 기존 테스트 영향 없음

## Backend API Compatibility
백엔드 Graph API (PR #157-#164)와 호환:
- `GET /api/evaluate/{id}/graph` → `ReactFlowGraph`
- `GET /api/evaluate/{id}/graph-3d` → `Graph3DPayload`
- `GET /api/evaluate/{id}/graph/timeline` → `TraceEvent[]`
- `GET /api/evaluate/{id}/graph/mode` → `ModeResponse`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 그래프 데이터 조회 API 추가
  * 3D 그래프 시각화 지원
  * 타임라인 이벤트 추적 기능
  * 그래프 모드 정보 조회 기능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->