### PR TITLE
feat(#167): [Graph Track][GF-2] 결과 페이지 탭 레이아웃 리팩터링

### DIFF
--- a/frontend/src/app/evaluate/[id]/result/page.tsx
+++ b/frontend/src/app/evaluate/[id]/result/page.tsx
@@ -1,10 +1,23 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, lazy, Suspense } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { api } from '../../../../lib/api';
 import { EvaluationResult } from '../../../../types';
-import { Wine, Award, Star, ArrowLeft, Share2, Download } from 'lucide-react';
+import { ArrowLeft, Share2, Download } from 'lucide-react';
+import { ResultTabs, useResultTab, ResultTabId } from '../../../../components/ResultTabs';
+import { TastingNotesTab } from '../../../../components/TastingNotesTab';
+
+const Graph2DTab = lazy(() => import('../../../../components/Graph2DTab').then(m => ({ default: m.Graph2DTab })));
+const Graph3DTab = lazy(() => import('../../../../components/Graph3DTab').then(m => ({ default: m.Graph3DTab })));
+
+function TabLoadingFallback() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#722F37]"></div>
+    </div>
+  );
+}
 
 export default function ResultPage() {
   const params = useParams();
@@ -14,6 +27,7 @@ export default function ResultPage() {
   const [result, setResult] = useState<EvaluationResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useResultTab('tasting');
 
   useEffect(() => {
     const fetchResult = async () => {
@@ -60,24 +74,31 @@ export default function ResultPage() {
     );
   }
 
-  const getTierColor = (score: number) => {
-    if (score >= 90) return 'text-[#722F37] bg-[#F7E7CE]';
-    if (score >= 80) return 'text-emerald-800 bg-emerald-100';
-    if (score >= 70) return 'text-blue-800 bg-blue-100';
-    return 'text-gray-800 bg-gray-100';
-  };
-
-  const getTierName = (score: number) => {
-    if (score >= 90) return 'Grand Cru';
-    if (score >= 80) return 'Premier Cru';
-    if (score >= 70) return 'Village';
-    return 'Table Wine';
+  const renderTabContent = (tabId: ResultTabId) => {
+    switch (tabId) {
+      case 'tasting':
+        return <TastingNotesTab result={result} />;
+      case 'graph-2d':
+        return (
+          <Suspense fallback={<TabLoadingFallback />}>
+            <Graph2DTab evaluationId={id} />
+          </Suspense>
+        );
+      case 'graph-3d':
+        return (
+          <Suspense fallback={<TabLoadingFallback />}>
+            <Graph3DTab evaluationId={id} />
+          </Suspense>
+        );
+      default:
+        return null;
+    }
   };
 
   return (
-    <div className="min-h-screen bg-[#FAFAFA] py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-5xl mx-auto">
-        <div className="flex justify-between items-center mb-8">
+    <div className="min-h-screen bg-[#FAFAFA]">
+      <div className="max-w-5xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center mb-6">
           <button
             onClick={() => router.push('/evaluate')}
             className="flex items-center text-gray-600 hover:text-[#722F37] transition-colors"
@@ -97,68 +118,9 @@ export default function ResultPage() {
           </div>
         </div>
 
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-8">
-          <div className="bg-[#722F37] text-white p-8 text-center relative overflow-hidden">
-            <div className="absolute top-0 left-0 w-full h-full opacity-10 bg-[url('https://www.transparenttextures.com/patterns/cubes.png')]"></div>
-            <h1 className="text-3xl font-serif font-bold mb-2 relative z-10">Tasting Notes</h1>
-            <p className="opacity-80 relative z-10">{result.repoUrl}</p>
-          </div>
-          
-          <div className="p-8">
-            <div className="flex flex-col md:flex-row items-center justify-center md:justify-between gap-8">
-              <div className="text-center md:text-left">
-                <div className={`inline-flex items-center px-4 py-1 rounded-full text-sm font-bold mb-2 ${getTierColor(result.totalScore || 0)}`}>
-                  <Award size={16} className="mr-2" />
-                  {getTierName(result.totalScore || 0)}
-                </div>
-                <h2 className="text-5xl font-bold text-[#722F37] mb-2">
-                  {result.totalScore}<span className="text-2xl text-gray-400 font-normal">/100</span>
-                </h2>
-                <p className="text-gray-500">Total Score</p>
-              </div>
+        <ResultTabs activeTab={activeTab} onTabChange={setActiveTab} />
 
-              <div className="flex-1 max-w-xl bg-[#FAFAFA] p-6 rounded-xl border border-gray-100">
-                <h3 className="font-serif font-bold text-[#722F37] mb-3 flex items-center">
-                  <Wine size={20} className="mr-2" />
-                  Jean-Pierre&apos;s Verdict
-                </h3>
-                <p className="text-gray-700 italic leading-relaxed">
-                  &quot;{result.finalVerdict}&quot;
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {result.results.map((somm) => (
-            <div key={somm.id} className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow">
-              <div className="flex justify-between items-start mb-4">
-                <div>
-                  <h3 className="font-bold text-gray-900">{somm.name}</h3>
-                  <p className="text-sm text-[#722F37]">{somm.role}</p>
-                </div>
-                <div className="flex items-center bg-gray-50 px-3 py-1 rounded-full">
-                  <Star size={14} className="text-yellow-500 mr-1 fill-current" />
-                  <span className="font-bold text-gray-900">{somm.score}</span>
-                </div>
-              </div>
-              
-              <p className="text-gray-600 text-sm mb-4 leading-relaxed">
-                {somm.feedback}
-              </p>
-
-              {somm.pairingSuggestion && (
-                <div className="mt-4 pt-4 border-t border-gray-100">
-                  <h4 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-1">Pairing Suggestion</h4>
-                  <p className="text-sm text-[#722F37] font-medium">
-                    {somm.pairingSuggestion}
-                  </p>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+        {renderTabContent(activeTab)}
       </div>
     </div>
   );

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,3 +24,21 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 150ms ease-out;
+}
+
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/frontend/src/components/Graph2DTab.tsx
+++ b/frontend/src/components/Graph2DTab.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React from 'react';
+import { BarChart3 } from 'lucide-react';
+
+interface Graph2DTabProps {
+  evaluationId: string;
+}
+
+export function Graph2DTab({ evaluationId }: Graph2DTabProps) {
+  return (
+    <div className="animate-fadeIn">
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-12 text-center">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[#F7E7CE] text-[#722F37] mb-4">
+          <BarChart3 size={32} />
+        </div>
+        <h2 className="text-2xl font-serif font-bold text-gray-900 mb-2">2D Graph Visualization</h2>
+        <p className="text-gray-500 mb-4">
+          Interactive ReactFlow graph showing the evaluation pipeline
+        </p>
+        <p className="text-sm text-gray-400">
+          Evaluation ID: {evaluationId}
+        </p>
+        <div className="mt-8 p-4 bg-gray-50 rounded-lg border border-dashed border-gray-300">
+          <p className="text-sm text-gray-500">
+            ReactFlow 2D Graph Viewer will be implemented in Issue #168
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Graph3DTab.tsx
+++ b/frontend/src/components/Graph3DTab.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React from 'react';
+import { Box } from 'lucide-react';
+
+interface Graph3DTabProps {
+  evaluationId: string;
+}
+
+export function Graph3DTab({ evaluationId }: Graph3DTabProps) {
+  return (
+    <div className="animate-fadeIn">
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-12 text-center">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[#F7E7CE] text-[#722F37] mb-4">
+          <Box size={32} />
+        </div>
+        <h2 className="text-2xl font-serif font-bold text-gray-900 mb-2">3D Graph Visualization</h2>
+        <p className="text-gray-500 mb-4">
+          Immersive Three.js graph with layered layout and edge bundling
+        </p>
+        <p className="text-sm text-gray-400">
+          Evaluation ID: {evaluationId}
+        </p>
+        <div className="mt-8 p-4 bg-gray-50 rounded-lg border border-dashed border-gray-300">
+          <p className="text-sm text-gray-500">
+            Three.js 3D Graph Viewer will be implemented in Issue #169
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ResultTabs.tsx
+++ b/frontend/src/components/ResultTabs.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React, { useEffect, useCallback } from 'react';
+import { Wine, BarChart3, Box } from 'lucide-react';
+
+export type ResultTabId = 'tasting' | 'graph-2d' | 'graph-3d';
+
+interface Tab {
+  id: ResultTabId;
+  label: string;
+  icon: React.ReactNode;
+  hash: string;
+  mobileHidden?: boolean;
+}
+
+const TABS: Tab[] = [
+  { id: 'tasting', label: 'Tasting Notes', icon: <Wine size={18} />, hash: '#tasting' },
+  { id: 'graph-2d', label: '2D Graph', icon: <BarChart3 size={18} />, hash: '#graph-2d' },
+  { id: 'graph-3d', label: '3D Graph', icon: <Box size={18} />, hash: '#graph-3d', mobileHidden: true },
+];
+
+interface ResultTabsProps {
+  activeTab: ResultTabId;
+  onTabChange: (tabId: ResultTabId) => void;
+}
+
+export function ResultTabs({ activeTab, onTabChange }: ResultTabsProps) {
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    const currentIndex = TABS.findIndex(t => t.id === activeTab);
+    if (e.key === 'ArrowRight') {
+      const nextIndex = (currentIndex + 1) % TABS.length;
+      onTabChange(TABS[nextIndex].id);
+    } else if (e.key === 'ArrowLeft') {
+      const prevIndex = (currentIndex - 1 + TABS.length) % TABS.length;
+      onTabChange(TABS[prevIndex].id);
+    }
+  }, [activeTab, onTabChange]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    const tab = TABS.find(t => t.hash === hash);
+    if (tab) {
+      onTabChange(tab.id);
+    }
+  }, [onTabChange]);
+
+  const handleTabClick = (tab: Tab) => {
+    onTabChange(tab.id);
+    window.history.replaceState(null, '', tab.hash);
+  };
+
+  return (
+    <div className="sticky top-0 z-10 bg-white border-b border-gray-200 mb-6">
+      <div className="flex overflow-x-auto scrollbar-hide">
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => handleTabClick(tab)}
+              className={`
+                flex items-center gap-2 px-6 py-4 font-medium text-sm whitespace-nowrap
+                transition-all duration-150 border-b-2
+                ${tab.mobileHidden ? 'hidden md:flex' : 'flex'}
+                ${isActive 
+                  ? 'text-[#722F37] border-[#722F37] bg-[#F7E7CE]/30' 
+                  : 'text-gray-600 border-transparent hover:text-[#722F37] hover:bg-gray-50'
+                }
+              `}
+              role="tab"
+              aria-selected={isActive}
+              tabIndex={isActive ? 0 : -1}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function useResultTab(initialTab: ResultTabId = 'tasting') {
+  const [activeTab, setActiveTab] = React.useState<ResultTabId>(initialTab);
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    const tab = TABS.find(t => t.hash === hash);
+    if (tab) {
+      setActiveTab(tab.id);
+    }
+  }, []);
+
+  return [activeTab, setActiveTab] as const;
+}

--- a/frontend/src/components/TastingNotesTab.tsx
+++ b/frontend/src/components/TastingNotesTab.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React from 'react';
+import { Wine, Award, Star } from 'lucide-react';
+import { EvaluationResult } from '../types';
+
+interface TastingNotesTabProps {
+  result: EvaluationResult;
+}
+
+function getTierColor(score: number): string {
+  if (score >= 90) return 'text-[#722F37] bg-[#F7E7CE]';
+  if (score >= 80) return 'text-emerald-800 bg-emerald-100';
+  if (score >= 70) return 'text-blue-800 bg-blue-100';
+  return 'text-gray-800 bg-gray-100';
+}
+
+function getTierName(score: number): string {
+  if (score >= 90) return 'Grand Cru';
+  if (score >= 80) return 'Premier Cru';
+  if (score >= 70) return 'Village';
+  return 'Table Wine';
+}
+
+export function TastingNotesTab({ result }: TastingNotesTabProps) {
+  return (
+    <div className="animate-fadeIn">
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-8">
+        <div className="bg-[#722F37] text-white p-8 text-center relative overflow-hidden">
+          <div className="absolute top-0 left-0 w-full h-full opacity-10 bg-[url('https://www.transparenttextures.com/patterns/cubes.png')]"></div>
+          <h1 className="text-3xl font-serif font-bold mb-2 relative z-10">Tasting Notes</h1>
+          <p className="opacity-80 relative z-10">{result.repoUrl}</p>
+        </div>
+        
+        <div className="p-8">
+          <div className="flex flex-col md:flex-row items-center justify-center md:justify-between gap-8">
+            <div className="text-center md:text-left">
+              <div className={`inline-flex items-center px-4 py-1 rounded-full text-sm font-bold mb-2 ${getTierColor(result.totalScore || 0)}`}>
+                <Award size={16} className="mr-2" />
+                {getTierName(result.totalScore || 0)}
+              </div>
+              <h2 className="text-5xl font-bold text-[#722F37] mb-2">
+                {result.totalScore}<span className="text-2xl text-gray-400 font-normal">/100</span>
+              </h2>
+              <p className="text-gray-500">Total Score</p>
+            </div>
+
+            <div className="flex-1 max-w-xl bg-[#FAFAFA] p-6 rounded-xl border border-gray-100">
+              <h3 className="font-serif font-bold text-[#722F37] mb-3 flex items-center">
+                <Wine size={20} className="mr-2" />
+                Jean-Pierre&apos;s Verdict
+              </h3>
+              <p className="text-gray-700 italic leading-relaxed">
+                &quot;{result.finalVerdict}&quot;
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {result.results.map((somm) => (
+          <div key={somm.id} className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow">
+            <div className="flex justify-between items-start mb-4">
+              <div>
+                <h3 className="font-bold text-gray-900">{somm.name}</h3>
+                <p className="text-sm text-[#722F37]">{somm.role}</p>
+              </div>
+              <div className="flex items-center bg-gray-50 px-3 py-1 rounded-full">
+                <Star size={14} className="text-yellow-500 mr-1 fill-current" />
+                <span className="font-bold text-gray-900">{somm.score}</span>
+              </div>
+            </div>
+            
+            <p className="text-gray-600 text-sm mb-4 leading-relaxed">
+              {somm.feedback}
+            </p>
+
+            {somm.pairingSuggestion && (
+              <div className="mt-4 pt-4 border-t border-gray-100">
+                <h4 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-1">Pairing Suggestion</h4>
+                <p className="text-sm text-[#722F37] font-medium">
+                  {somm.pairingSuggestion}
+                </p>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Resolves #167

결과 페이지를 탭 기반으로 리팩터링하여 Tasting Notes / 2D Graph / 3D Graph 전환 지원

## Changes

### 1. 새 컴포넌트
- `ResultTabs.tsx` - 탭 네비게이션 (URL hash, 키보드 지원)
- `TastingNotesTab.tsx` - 기존 결과 카드 추출
- `Graph2DTab.tsx` - ReactFlow 플레이스홀더 (#168에서 구현)
- `Graph3DTab.tsx` - Three.js 플레이스홀더 (#169에서 구현)

### 2. 탭 구조
```
┌──────────────────┬──────────────────┬──────────────────┐
│  🍷 Tasting Notes │  📊 2D Graph     │  🌐 3D Graph     │
│  (기존 결과 카드)  │  (ReactFlow)     │  (Three.js)      │
└──────────────────┴──────────────────┴──────────────────┘
```

### 3. 기능
- URL hash 기반 딥링크 (`#tasting`, `#graph-2d`, `#graph-3d`)
- 키보드 네비게이션 (← → 화살표 키)
- 모바일: 3D 탭 숨김 (반응형)
- lazy load로 그래프 탭 임포트 (성능 최적화)
- fade-in 애니메이션 (150ms)

## Testing
- [x] 빌드 성공 (`npm run build`)
- [x] 기존 Tasting Notes 기능 100% 유지 (리그레션 없음)
- [x] 탭 전환 동작 확인
- [x] URL hash 딥링크 동작

## Screenshots
탭 UI가 결과 페이지 상단에 추가됨