### PR TITLE
feat(#168): [Graph Track][GF-3] ReactFlow 2D Graph Viewer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "somm",
       "version": "0.1.0",
       "dependencies": {
+        "@types/dagre": "^0.7.53",
+        "@xyflow/react": "^12.10.0",
+        "dagre": "^0.8.5",
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -2484,6 +2487,61 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/dagre": {
+      "version": "0.7.53",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.53.tgz",
+      "integrity": "sha512-f4gkWqzPZvYmKhOsDnhq/R8mO4UMcKdxZo+i5SCkOU1wvGeHJeUXGIHeE9pnwGyPMDof1Vx5ZQo4nxpeg2TTVQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2568,7 +2626,7 @@
       "version": "19.2.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3152,6 +3210,38 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.0.tgz",
+      "integrity": "sha512-eOtz3whDMWrB4KWVatIBrKuxECHqip6PfA8fTpaS2RUGVpiEAe+nqDKsLqkViVWxDGreq0lWX71Xth/SPAzXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.74",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.74",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.74.tgz",
+      "integrity": "sha512-7v7B/PkiVrkdZzSbL+inGAo6tkR/WQHHG0/jhSvLQToCsfa8YubOGmBYd1s08tpKpihdHDZFwzQZeR69QSBb4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -3878,6 +3968,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -4120,8 +4216,123 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5605,6 +5816,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -7911,6 +8131,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10209,6 +10435,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10568,6 +10803,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,16 +13,19 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@types/dagre": "^0.7.53",
+    "@xyflow/react": "^12.10.0",
+    "dagre": "^0.8.5",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
-    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/frontend/src/components/Graph2DTab.tsx
+++ b/frontend/src/components/Graph2DTab.tsx
@@ -1,32 +1,143 @@
 'use client';
 
-import React from 'react';
-import { BarChart3 } from 'lucide-react';
+import React, { useEffect, useCallback, useState } from 'react';
+import { 
+  ReactFlow, 
+  MiniMap, 
+  Controls, 
+  Background, 
+  useNodesState, 
+  useEdgesState,
+  Node,
+  Edge,
+  Connection,
+  addEdge,
+  BackgroundVariant
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { api } from '@/lib/api';
+import { nodeTypes } from './graph/nodes';
+import { getLayoutedElements } from '@/lib/graphLayout';
+import { Loader2, AlertCircle, RefreshCw } from 'lucide-react';
 
 interface Graph2DTabProps {
   evaluationId: string;
 }
 
 export function Graph2DTab({ evaluationId }: Graph2DTabProps) {
-  return (
-    <div className="animate-fadeIn">
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-12 text-center">
-        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[#F7E7CE] text-[#722F37] mb-4">
-          <BarChart3 size={32} />
-        </div>
-        <h2 className="text-2xl font-serif font-bold text-gray-900 mb-2">2D Graph Visualization</h2>
-        <p className="text-gray-500 mb-4">
-          Interactive ReactFlow graph showing the evaluation pipeline
-        </p>
-        <p className="text-sm text-gray-400">
-          Evaluation ID: {evaluationId}
-        </p>
-        <div className="mt-8 p-4 bg-gray-50 rounded-lg border border-dashed border-gray-300">
-          <p className="text-sm text-gray-500">
-            ReactFlow 2D Graph Viewer will be implemented in Issue #168
-          </p>
-        </div>
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const graphData = await api.getGraph(evaluationId);
+      
+      // Transform API nodes to ReactFlow nodes
+      const initialNodes: Node[] = graphData.nodes.map(node => ({
+        id: node.id,
+        type: node.type,
+        position: node.position || { x: 0, y: 0 },
+        data: node.data,
+      }));
+
+      // Transform API edges to ReactFlow edges
+      const initialEdges: Edge[] = graphData.edges.map(edge => ({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        animated: true,
+        style: { stroke: '#722F37', strokeWidth: 2 },
+      }));
+
+      // Apply layout
+      const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
+        initialNodes,
+        initialEdges
+      );
+
+      setNodes(layoutedNodes);
+      setEdges(layoutedEdges);
+    } catch (err) {
+      console.error('Failed to fetch graph data:', err);
+      setError('Failed to load graph data. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [evaluationId, setNodes, setEdges]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const onConnect = useCallback(
+    (params: Connection) => setEdges((eds) => addEdge(params, eds)),
+    [setEdges],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[600px] bg-white rounded-2xl shadow-sm border border-gray-100">
+        <Loader2 className="w-10 h-10 text-[#722F37] animate-spin mb-4" />
+        <p className="text-gray-500 font-medium">Loading graph visualization...</p>
       </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[600px] bg-white rounded-2xl shadow-sm border border-gray-100">
+        <AlertCircle className="w-10 h-10 text-red-500 mb-4" />
+        <p className="text-gray-800 font-medium mb-2">{error}</p>
+        <button 
+          onClick={fetchData}
+          className="flex items-center px-4 py-2 bg-[#722F37] text-white rounded-lg hover:bg-[#5D262D] transition-colors"
+        >
+          <RefreshCw size={16} className="mr-2" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[800px] bg-[#FAFAFA] rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        nodeTypes={nodeTypes}
+        fitView
+        attributionPosition="bottom-left"
+        minZoom={0.1}
+        maxZoom={1.5}
+      >
+        <Controls className="!bg-white !border-gray-200 !shadow-sm" />
+        <MiniMap 
+          className="!bg-white !border-gray-200 !shadow-sm"
+          nodeColor={(node) => {
+            switch (node.type) {
+              case 'start':
+              case 'end':
+                return '#722F37';
+              case 'agent':
+                return '#2E4A3F';
+              case 'technique':
+                return '#F7E7CE';
+              case 'synthesis':
+                return '#DAA520';
+              default:
+                return '#eee';
+            }
+          }}
+        />
+        <Background variant={BackgroundVariant.Dots} gap={12} size={1} color="#E5E7EB" />
+      </ReactFlow>
     </div>
   );
 }

--- a/frontend/src/components/graph/nodes/AgentNode.tsx
+++ b/frontend/src/components/graph/nodes/AgentNode.tsx
@@ -1,0 +1,59 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+import { User, CheckCircle, XCircle, Clock, Loader2 } from 'lucide-react';
+
+const AgentNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  const statusColor = {
+    pending: 'bg-gray-100 text-gray-500',
+    running: 'bg-blue-100 text-blue-600',
+    completed: 'bg-green-100 text-green-600',
+    failed: 'bg-red-100 text-red-600',
+  };
+
+  const StatusIcon = {
+    pending: Clock,
+    running: Loader2,
+    completed: CheckCircle,
+    failed: XCircle,
+  };
+
+  const status = data.status || 'pending';
+  const Icon = StatusIcon[status];
+
+  return (
+    <div className="w-64 bg-white rounded-lg shadow-md border border-gray-200 overflow-hidden">
+      <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-gray-400" />
+      
+      <div className="h-2 w-full" style={{ backgroundColor: data.color || '#722F37' }} />
+      
+      <div className="p-4">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center text-gray-600">
+              <User size={20} />
+            </div>
+            <div>
+              <h3 className="font-bold text-gray-900 text-sm">{data.label}</h3>
+              <p className="text-xs text-gray-500">{data.hatType || 'Sommelier'}</p>
+            </div>
+          </div>
+          
+          <div className={`p-1 rounded-full ${status === 'running' ? 'animate-spin' : ''}`}>
+            <Icon size={16} className={status === 'completed' ? 'text-green-500' : status === 'failed' ? 'text-red-500' : 'text-gray-400'} />
+          </div>
+        </div>
+        
+        {data.status && (
+          <div className={`mt-3 px-2 py-1 rounded text-xs font-medium inline-block ${statusColor[status]}`}>
+            {status.toUpperCase()}
+          </div>
+        )}
+      </div>
+      
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3 !bg-gray-400" />
+    </div>
+  );
+};
+
+export default memo(AgentNode);

--- a/frontend/src/components/graph/nodes/EndNode.tsx
+++ b/frontend/src/components/graph/nodes/EndNode.tsx
@@ -1,0 +1,21 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+
+const EndNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="w-3 h-3 !bg-[#722F37]"
+      />
+      <div className="w-16 h-16 rounded-full bg-[#722F37] flex items-center justify-center shadow-lg border-2 border-[#F7E7CE]">
+        <span className="text-white font-bold text-xs">END</span>
+      </div>
+      <div className="mt-2 text-sm font-medium text-gray-700">{data.label}</div>
+    </div>
+  );
+};
+
+export default memo(EndNode);

--- a/frontend/src/components/graph/nodes/RagNode.tsx
+++ b/frontend/src/components/graph/nodes/RagNode.tsx
@@ -1,0 +1,30 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+import { Database, Search } from 'lucide-react';
+
+const RagNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  return (
+    <div className="w-48 bg-slate-50 rounded-lg shadow-sm border border-slate-200 p-3 flex items-center space-x-3">
+      <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-slate-400" />
+      
+      <div className="w-10 h-10 rounded bg-slate-200 flex items-center justify-center text-slate-600 flex-shrink-0">
+        <Database size={18} />
+      </div>
+      
+      <div className="flex-1 min-w-0">
+        <h4 className="font-medium text-slate-800 text-sm truncate" title={data.label}>
+          {data.label}
+        </h4>
+        <div className="flex items-center text-xs text-slate-500 mt-0.5">
+          <Search size={10} className="mr-1" />
+          <span>Retrieval</span>
+        </div>
+      </div>
+      
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3 !bg-slate-400" />
+    </div>
+  );
+};
+
+export default memo(RagNode);

--- a/frontend/src/components/graph/nodes/StartNode.tsx
+++ b/frontend/src/components/graph/nodes/StartNode.tsx
@@ -1,0 +1,21 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+
+const StartNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <div className="w-16 h-16 rounded-full bg-[#722F37] flex items-center justify-center shadow-lg border-2 border-[#F7E7CE]">
+        <span className="text-white font-bold text-xs">START</span>
+      </div>
+      <div className="mt-2 text-sm font-medium text-gray-700">{data.label}</div>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="w-3 h-3 !bg-[#722F37]"
+      />
+    </div>
+  );
+};
+
+export default memo(StartNode);

--- a/frontend/src/components/graph/nodes/SynthesisNode.tsx
+++ b/frontend/src/components/graph/nodes/SynthesisNode.tsx
@@ -1,0 +1,38 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+import { Star, Award } from 'lucide-react';
+
+const SynthesisNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  return (
+    <div className="w-72 bg-gradient-to-br from-[#722F37] to-[#5D262D] rounded-lg shadow-xl border border-[#F7E7CE] text-white overflow-hidden">
+      <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-[#F7E7CE]" />
+      
+      <div className="p-4">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center space-x-2">
+            <Award className="text-[#F7E7CE]" size={20} />
+            <span className="font-bold text-[#F7E7CE] text-xs tracking-wider uppercase">Final Verdict</span>
+          </div>
+          <Star className="text-[#F7E7CE] fill-[#F7E7CE]" size={16} />
+        </div>
+        
+        <h3 className="font-serif text-xl font-bold mb-1">{data.label}</h3>
+        <p className="text-white/80 text-xs">Synthesis & Scoring</p>
+        
+        {data.status === 'completed' && (
+          <div className="mt-3 pt-3 border-t border-white/20 flex justify-between items-center">
+            <span className="text-xs text-white/70">Evaluation Complete</span>
+            <span className="bg-[#F7E7CE] text-[#722F37] text-xs font-bold px-2 py-0.5 rounded">
+              DONE
+            </span>
+          </div>
+        )}
+      </div>
+      
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3 !bg-[#F7E7CE]" />
+    </div>
+  );
+};
+
+export default memo(SynthesisNode);

--- a/frontend/src/components/graph/nodes/TechniqueNode.tsx
+++ b/frontend/src/components/graph/nodes/TechniqueNode.tsx
@@ -1,0 +1,28 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+import { FileText } from 'lucide-react';
+
+const TechniqueNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  return (
+    <div className="w-56 bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition-shadow">
+      <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-gray-400" />
+      
+      <div className="p-3 border-l-4" style={{ borderLeftColor: data.color || '#F7E7CE' }}>
+        <div className="flex items-start space-x-2">
+          <FileText size={16} className="text-gray-400 mt-1 flex-shrink-0" />
+          <div>
+            <h4 className="font-medium text-gray-900 text-sm leading-tight">{data.label}</h4>
+            {data.category && (
+              <span className="text-xs text-gray-500 mt-1 block">{data.category}</span>
+            )}
+          </div>
+        </div>
+      </div>
+      
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3 !bg-gray-400" />
+    </div>
+  );
+};
+
+export default memo(TechniqueNode);

--- a/frontend/src/components/graph/nodes/index.ts
+++ b/frontend/src/components/graph/nodes/index.ts
@@ -1,0 +1,16 @@
+import StartNode from './StartNode';
+import EndNode from './EndNode';
+import AgentNode from './AgentNode';
+import TechniqueNode from './TechniqueNode';
+import SynthesisNode from './SynthesisNode';
+import RagNode from './RagNode';
+
+export const nodeTypes = {
+  start: StartNode,
+  end: EndNode,
+  agent: AgentNode,
+  technique: TechniqueNode,
+  synthesis: SynthesisNode,
+  rag: RagNode,
+  process: TechniqueNode, // Fallback for process nodes
+};

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -1,0 +1,56 @@
+import dagre from 'dagre';
+import { Node, Edge, Position } from '@xyflow/react';
+
+const dagreGraph = new dagre.graphlib.Graph();
+dagreGraph.setDefaultEdgeLabel(() => ({}));
+
+const nodeWidth = 250;
+const nodeHeight = 100;
+
+export const getLayoutedElements = (nodes: Node[], edges: Edge[], direction = 'TB') => {
+  const isHorizontal = direction === 'LR';
+  dagreGraph.setGraph({ rankdir: direction, nodesep: 80, ranksep: 120 });
+
+  nodes.forEach((node) => {
+    // Adjust dimensions based on node type if needed
+    let width = nodeWidth;
+    let height = nodeHeight;
+    
+    if (node.type === 'start' || node.type === 'end') {
+      width = 80;
+      height = 80;
+    } else if (node.type === 'synthesis') {
+      width = 300;
+      height = 150;
+    }
+
+    dagreGraph.setNode(node.id, { width, height });
+  });
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  const layoutedNodes = nodes.map((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    
+    // We are shifting the dagre node position (anchor=center center) to the top left
+    // so it matches the React Flow node anchor point (top left).
+    const width = node.measured?.width ?? (node.type === 'start' || node.type === 'end' ? 80 : nodeWidth);
+    const height = node.measured?.height ?? (node.type === 'start' || node.type === 'end' ? 80 : nodeHeight);
+
+    return {
+      ...node,
+      targetPosition: isHorizontal ? Position.Left : Position.Top,
+      sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+      position: {
+        x: nodeWithPosition.x - width / 2,
+        y: nodeWithPosition.y - height / 2,
+      },
+    };
+  });
+
+  return { nodes: layoutedNodes, edges };
+};


### PR DESCRIPTION
## Summary
Resolves #168

ReactFlow 기반 2D 그래프 시각화 구현

## Changes

### 1. 의존성 설치
- `@xyflow/react` - ReactFlow 라이브러리
- `dagre` + `@types/dagre` - 자동 레이아웃

### 2. 커스텀 노드 컴포넌트 (`components/graph/nodes/`)
| 노드 | 설명 |
|------|------|
| `StartNode` | 시작 노드 (원형, 와인색) |
| `EndNode` | 종료 노드 (원형, 와인색) |
| `AgentNode` | 소믈리에 에이전트 (카드형, 상태 배지) |
| `TechniqueNode` | Tasting Note 카테고리 (카드형) |
| `SynthesisNode` | Jean-Pierre 합성 노드 (강조 카드형) |
| `RagNode` | RAG Enrichment (데이터베이스 아이콘) |

### 3. Dagre 자동 레이아웃
- `lib/graphLayout.ts` - Top-to-Bottom 레이아웃
- Node separation: 80px, Rank separation: 120px

### 4. Graph2DTab 업데이트
- `api.getGraph()` 호출로 데이터 페칭
- MiniMap + Controls 통합
- 애니메이션 엣지
- 로딩/에러 상태 처리

## Testing
- [x] 빌드 성공 (`npm run build`)
- [x] 커스텀 노드 6종 생성
- [x] 와인 테마 적용 (#722F37, #F7E7CE)

## Supported Topologies
- Six Sommeliers: `START → RAG → [5 agents] → JP → END`
- Grand Tasting: `START → RAG → Baseline → [8 categories] → Synthesis → END`