### PR TITLE
feat(#170): implement timeline player with graph integration

### DIFF
--- a/frontend/src/components/graph/TimelinePlayer.tsx
+++ b/frontend/src/components/graph/TimelinePlayer.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect } from 'react';
+import { Play, Pause, ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface TimelinePlayerProps {
+  currentStep: number;
+  maxStep: number;
+  isPlaying: boolean;
+  onStepChange: (step: number) => void;
+  onPlayPause: () => void;
+  playbackSpeed?: number;
+  onSpeedChange?: (speed: number) => void;
+}
+
+export function TimelinePlayer({
+  currentStep,
+  maxStep,
+  isPlaying,
+  onStepChange,
+  onPlayPause,
+  playbackSpeed = 1,
+  onSpeedChange,
+}: TimelinePlayerProps) {
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Only trigger if not typing in an input
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      switch (e.key) {
+        case ' ':
+          e.preventDefault();
+          onPlayPause();
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          onStepChange(Math.max(0, currentStep - 1));
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          onStepChange(Math.min(maxStep, currentStep + 1));
+          break;
+        case '1':
+          onSpeedChange?.(0.5);
+          break;
+        case '2':
+          onSpeedChange?.(1);
+          break;
+        case '3':
+          onSpeedChange?.(2);
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [currentStep, maxStep, onPlayPause, onStepChange, onSpeedChange]);
+
+  return (
+    <div className="flex flex-col gap-2 p-4 bg-white border border-[#F7E7CE] rounded-lg shadow-sm w-full max-w-3xl mx-auto">
+      <div className="flex items-center justify-between gap-4">
+        {/* Controls */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => onStepChange(Math.max(0, currentStep - 1))}
+            disabled={currentStep <= 0}
+            className="p-2 text-[#722F37] hover:bg-[#F7E7CE]/20 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            aria-label="Previous step"
+          >
+            <ChevronLeft size={20} />
+          </button>
+
+          <button
+            onClick={onPlayPause}
+            className="p-3 bg-[#722F37] text-white rounded-full hover:bg-[#5a252c] transition-colors shadow-md"
+            aria-label={isPlaying ? "Pause" : "Play"}
+          >
+            {isPlaying ? <Pause size={20} fill="currentColor" /> : <Play size={20} fill="currentColor" className="ml-0.5" />}
+          </button>
+
+          <button
+            onClick={() => onStepChange(Math.min(maxStep, currentStep + 1))}
+            disabled={currentStep >= maxStep}
+            className="p-2 text-[#722F37] hover:bg-[#F7E7CE]/20 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            aria-label="Next step"
+          >
+            <ChevronRight size={20} />
+          </button>
+        </div>
+
+        {/* Step Counter */}
+        <div className="font-mono text-sm font-medium text-[#722F37] min-w-[80px] text-center">
+          Step {currentStep}/{maxStep}
+        </div>
+
+        {/* Slider */}
+        <div className="flex-1 px-2">
+          <input
+            type="range"
+            min={0}
+            max={maxStep}
+            value={currentStep}
+            onChange={(e) => onStepChange(parseInt(e.target.value))}
+            className="w-full h-2 bg-[#F7E7CE] rounded-lg appearance-none cursor-pointer accent-[#722F37]"
+          />
+        </div>
+
+        {/* Speed Selector */}
+        {onSpeedChange && (
+          <div className="flex items-center bg-[#F7E7CE]/30 rounded-lg p-1">
+            {[0.5, 1, 2].map((speed) => (
+              <button
+                key={speed}
+                onClick={() => onSpeedChange(speed)}
+                className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
+                  playbackSpeed === speed
+                    ? 'bg-[#722F37] text-white shadow-sm'
+                    : 'text-[#722F37] hover:bg-[#F7E7CE]/50'
+                }`}
+              >
+                {speed}x
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTimelinePlayer.ts
+++ b/frontend/src/hooks/useTimelinePlayer.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export function useTimelinePlayer(maxStep: number) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackSpeed, setPlaybackSpeed] = useState(1);
+
+  // Auto-advance when playing
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (isPlaying && currentStep < maxStep) {
+      timer = setTimeout(() => {
+        setCurrentStep((s) => {
+          if (s >= maxStep) {
+            setIsPlaying(false);
+            return s;
+          }
+          return s + 1;
+        });
+      }, 1000 / playbackSpeed);
+    } else if (currentStep >= maxStep) {
+      setIsPlaying(false);
+    }
+    return () => clearTimeout(timer);
+  }, [isPlaying, currentStep, maxStep, playbackSpeed]);
+
+  const togglePlay = useCallback(() => {
+    if (currentStep >= maxStep) {
+      setCurrentStep(0);
+      setIsPlaying(true);
+    } else {
+      setIsPlaying((p) => !p);
+    }
+  }, [currentStep, maxStep]);
+
+  const nextStep = useCallback(() => {
+    setCurrentStep((s) => Math.min(s + 1, maxStep));
+    setIsPlaying(false);
+  }, [maxStep]);
+
+  const prevStep = useCallback(() => {
+    setCurrentStep((s) => Math.max(s - 1, 0));
+    setIsPlaying(false);
+  }, []);
+
+  const setStep = useCallback((step: number) => {
+    setCurrentStep(Math.max(0, Math.min(step, maxStep)));
+    setIsPlaying(false); // Pause when manually setting step
+  }, [maxStep]);
+
+  return {
+    currentStep,
+    setCurrentStep: setStep,
+    isPlaying,
+    setIsPlaying,
+    togglePlay,
+    nextStep,
+    prevStep,
+    playbackSpeed,
+    setPlaybackSpeed,
+  };
+}


### PR DESCRIPTION
## Summary
- Implemented `TimelinePlayer` component with playback controls (play/pause, prev/next, slider, speed).
- Created `useTimelinePlayer` hook for managing playback state and auto-advancement.
- Integrated `TimelinePlayer` into `Graph2DTab` to filter node visibility (opacity) based on the current step.
- Integrated `TimelinePlayer` into `Graph3DTab` to filter node/edge visibility based on the current step.
- Added keyboard shortcuts (Space, Arrows, 1/2/3) for easier navigation.
- Updated `GraphView3D` to accept `currentStep` prop.

## Key Changes
- `frontend/src/components/graph/TimelinePlayer.tsx`: New component.
- `frontend/src/hooks/useTimelinePlayer.ts`: New hook.
- `frontend/src/components/Graph2DTab.tsx`: Integration.
- `frontend/src/components/Graph3DTab.tsx`: Integration.
- `frontend/src/components/graph/GraphView3D.tsx`: Updated to support step filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 그래프 시각화에 타임라인 기반 재생 컨트롤 추가
* 스텝별로 노드를 점진적으로 표시하는 기능 (미래 노드는 반투명하게 표시)
* 재생/일시정지, 이전/다음 버튼, 스텝 슬라이더를 포함한 타임라인 플레이어 UI
* 재생 속도 조절 옵션 (0.5x, 1x, 2x)
* 키보드 단축키 지원 (스페이스: 재생, 화살표: 스텝 이동, 1/2/3: 속도 설정)
* 2D 및 3D 그래프 뷰에 모두 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->