### PR TITLE
test(#173): add comprehensive frontend graph test suite

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
+  },
+};

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/__tests__/graph/GraphSkeleton.test.tsx
+++ b/frontend/src/__tests__/graph/GraphSkeleton.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { GraphSkeleton } from '@/components/graph/GraphSkeleton';
+
+describe('GraphSkeleton', () => {
+  it('renders skeleton container', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const skeletonContainer = container.firstChild;
+    expect(skeletonContainer).toBeInTheDocument();
+  });
+
+  it('renders loading text', () => {
+    render(<GraphSkeleton />);
+
+    expect(screen.getByText('Decanting your graph...')).toBeInTheDocument();
+  });
+
+  it('renders 9 placeholder nodes in a grid', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const gridContainer = container.querySelector('.grid');
+    expect(gridContainer).toBeInTheDocument();
+
+    const pulseElements = container.querySelectorAll('.animate-pulse');
+    expect(pulseElements.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it('renders bouncing dots at the bottom', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const bounceElements = container.querySelectorAll('.animate-bounce');
+    expect(bounceElements.length).toBe(3);
+  });
+
+  it('has shimmer animation element', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const shimmerElement = container.querySelector('.animate-shimmer');
+    expect(shimmerElement).toBeInTheDocument();
+  });
+
+  it('has correct background styling', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const skeletonContainer = container.firstChild as HTMLElement;
+    expect(skeletonContainer).toHaveClass('bg-neutral-50/50');
+  });
+
+  it('has rounded corners', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const skeletonContainer = container.firstChild as HTMLElement;
+    expect(skeletonContainer).toHaveClass('rounded-lg');
+  });
+
+  it('has border styling', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const skeletonContainer = container.firstChild as HTMLElement;
+    expect(skeletonContainer).toHaveClass('border', 'border-neutral-200');
+  });
+
+  it('renders radial gradient background pattern', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const radialBackground = container.querySelector('.opacity-10');
+    expect(radialBackground).toBeInTheDocument();
+    expect(radialBackground).toHaveStyle({
+      backgroundImage: 'radial-gradient(#722F37 1px, transparent 1px)',
+    });
+  });
+
+  it('renders SVG with connecting lines', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+
+    const path = svg?.querySelector('path');
+    expect(path).toBeInTheDocument();
+  });
+
+  it('renders pulse animation with staggered delays', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    const gridItems = container.querySelectorAll('.grid > div');
+    expect(gridItems.length).toBe(9);
+
+    gridItems.forEach((item, index) => {
+      expect(item).toHaveStyle({
+        animationDelay: `${index * 100}ms`,
+      });
+    });
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(<GraphSkeleton />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/graph/ModeIndicatorBadge.test.tsx
+++ b/frontend/src/__tests__/graph/ModeIndicatorBadge.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ModeIndicatorBadge } from '@/components/ModeIndicatorBadge';
+import { GraphEvaluationMode } from '@/types/graph';
+
+describe('ModeIndicatorBadge', () => {
+  it('renders "Standard Tasting" for six_hats mode', () => {
+    render(<ModeIndicatorBadge mode="six_hats" />);
+
+    expect(screen.getByText('Standard Tasting')).toBeInTheDocument();
+  });
+
+  it('renders "Grand Tasting" for full_techniques mode', () => {
+    render(<ModeIndicatorBadge mode="full_techniques" />);
+
+    expect(screen.getByText('Grand Tasting')).toBeInTheDocument();
+  });
+
+  it('renders description text for Standard Tasting', () => {
+    render(<ModeIndicatorBadge mode="six_hats" />);
+
+    expect(screen.getByText('Six Sommeliers · ~2min')).toBeInTheDocument();
+  });
+
+  it('renders description text for Grand Tasting', () => {
+    render(<ModeIndicatorBadge mode="full_techniques" />);
+
+    expect(screen.getByText('Sommelier Masterclass · 75 techniques · ~5min')).toBeInTheDocument();
+  });
+
+  it('renders Wine icon for six_hats mode', () => {
+    const { container } = render(<ModeIndicatorBadge mode="six_hats" />);
+
+    const wineIcon = container.querySelector('svg');
+    expect(wineIcon).toBeInTheDocument();
+  });
+
+  it('renders Trophy icon for full_techniques mode', () => {
+    const { container } = render(<ModeIndicatorBadge mode="full_techniques" />);
+
+    const trophyIcon = container.querySelector('svg');
+    expect(trophyIcon).toBeInTheDocument();
+  });
+
+  it('applies burgundy styling for six_hats mode', () => {
+    render(<ModeIndicatorBadge mode="six_hats" />);
+
+    const badge = screen.getByText('Standard Tasting').closest('div')?.parentElement;
+    expect(badge).toHaveClass('from-[#F7E7CE]/30', 'to-[#F7E7CE]/10');
+  });
+
+  it('applies amber styling for full_techniques mode', () => {
+    render(<ModeIndicatorBadge mode="full_techniques" />);
+
+    const badge = screen.getByText('Grand Tasting').closest('div')?.parentElement;
+    expect(badge).toHaveClass('from-amber-50', 'to-yellow-50');
+  });
+
+  it('renders six_hats as default for unknown mode strings', () => {
+    render(<ModeIndicatorBadge mode="unknown_mode" as GraphEvaluationMode />);
+
+    expect(screen.getByText('Standard Tasting')).toBeInTheDocument();
+  });
+
+  it('has correct border styling for six_hats mode', () => {
+    render(<ModeIndicatorBadge mode="six_hats" />);
+
+    const badge = screen.getByText('Standard Tasting').closest('div')?.parentElement;
+    expect(badge).toHaveClass('border-[#F7E7CE]');
+  });
+
+  it('has correct border styling for full_techniques mode', () => {
+    render(<ModeIndicatorBadge mode="full_techniques" />);
+
+    const badge = screen.getByText('Grand Tasting').closest('div')?.parentElement;
+    expect(badge).toHaveClass('border-amber-200');
+  });
+
+  it('matches snapshot for six_hats mode', () => {
+    const { container } = render(<ModeIndicatorBadge mode="six_hats" />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot for full_techniques mode', () => {
+    const { container } = render(<ModeIndicatorBadge mode="full_techniques" />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/graph/ResultTabs.test.tsx
+++ b/frontend/src/__tests__/graph/ResultTabs.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ResultTabs, ResultTabId } from '@/components/ResultTabs';
+
+// Mock window.location and window.history
+const mockReplaceState = jest.fn();
+Object.defineProperty(window, 'location', {
+  value: { hash: '' },
+  writable: true,
+});
+Object.defineProperty(window, 'history', {
+  value: { replaceState: mockReplaceState },
+  writable: true,
+});
+
+describe('ResultTabs', () => {
+  const mockOnTabChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnTabChange.mockClear();
+    mockReplaceState.mockClear();
+    window.location.hash = '';
+  });
+
+  afterEach(() => {
+    // Clean up event listeners
+    window.removeEventListener('keydown', expect.any(Function));
+  });
+
+  it('renders all tabs correctly', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    expect(screen.getByRole('tab', { name: /Tasting Notes/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /2D Graph/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /3D Graph/i })).toBeInTheDocument();
+  });
+
+  it('marks the active tab as selected', () => {
+    render(
+      <ResultTabs activeTab="graph-2d" onTabChange={mockOnTabChange} />
+    );
+
+    const tastingTab = screen.getByRole('tab', { name: /Tasting Notes/i });
+    const graph2dTab = screen.getByRole('tab', { name: /2D Graph/i });
+    const graph3dTab = screen.getByRole('tab', { name: /3D Graph/i });
+
+    expect(tastingTab).toHaveAttribute('aria-selected', 'false');
+    expect(graph2dTab).toHaveAttribute('aria-selected', 'true');
+    expect(graph3dTab).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('hides 3D tab on mobile (mobileHidden prop)', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    const graph3dTab = screen.getByRole('tab', { name: /3D Graph/i });
+    expect(graph3dTab).toHaveClass('hidden', 'md:flex');
+  });
+
+  it('does not hide tasting or 2D tabs on mobile', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    const tastingTab = screen.getByRole('tab', { name: /Tasting Notes/i });
+    const graph2dTab = screen.getByRole('tab', { name: /2D Graph/i });
+
+    expect(tastingTab).not.toHaveClass('hidden');
+    expect(graph2dTab).not.toHaveClass('hidden');
+  });
+
+  it('calls onTabChange when a tab is clicked', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    const graph2dTab = screen.getByRole('tab', { name: /2D Graph/i });
+    fireEvent.click(graph2dTab);
+
+    expect(mockOnTabChange).toHaveBeenCalledWith('graph-2d');
+  });
+
+  it('updates URL hash when tab is clicked', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    const graph3dTab = screen.getByRole('tab', { name: /3D Graph/i });
+    fireEvent.click(graph3dTab);
+
+    expect(mockReplaceState).toHaveBeenCalledWith(null, '', '#graph-3d');
+  });
+
+  it('handles keyboard navigation with ArrowRight', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    expect(mockOnTabChange).toHaveBeenCalledWith('graph-2d');
+  });
+
+  it('handles keyboard navigation with ArrowLeft', () => {
+    render(
+      <ResultTabs activeTab="graph-2d" onTabChange={mockOnTabChange} />
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+
+    expect(mockOnTabChange).toHaveBeenCalledWith('tasting');
+  });
+
+  it('wraps around to first tab when pressing ArrowRight on last tab', () => {
+    render(
+      <ResultTabs activeTab="graph-3d" onTabChange={mockOnTabChange} />
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    expect(mockOnTabChange).toHaveBeenCalledWith('tasting');
+  });
+
+  it('wraps around to last tab when pressing ArrowLeft on first tab', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+
+    expect(mockOnTabChange).toHaveBeenCalledWith('graph-3d');
+  });
+
+  it('sets active tab based on URL hash on mount', () => {
+    window.location.hash = '#graph-2d';
+
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    expect(mockOnTabChange).toHaveBeenCalledWith('graph-2d');
+  });
+
+  it('ignores unknown hash values', () => {
+    window.location.hash = '#unknown-tab';
+
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    expect(mockOnTabChange).not.toHaveBeenCalled();
+  });
+
+  it('has correct active styling for selected tab', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    const tastingTab = screen.getByRole('tab', { name: /Tasting Notes/i });
+    expect(tastingTab).toHaveClass('text-[#722F37]', 'border-[#722F37]');
+  });
+
+  it('has correct inactive styling for unselected tabs', () => {
+    render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    const graph2dTab = screen.getByRole('tab', { name: /2D Graph/i });
+    expect(graph2dTab).toHaveClass('text-gray-600', 'border-transparent');
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(
+      <ResultTabs activeTab="tasting" onTabChange={mockOnTabChange} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot with graph-2d active', () => {
+    const { container } = render(
+      <ResultTabs activeTab="graph-2d" onTabChange={mockOnTabChange} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/graph/TimelinePlayer.test.tsx
+++ b/frontend/src/__tests__/graph/TimelinePlayer.test.tsx
@@ -1,0 +1,528 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TimelinePlayer } from '@/components/graph/TimelinePlayer';
+
+describe('TimelinePlayer', () => {
+  const mockOnStepChange = jest.fn();
+  const mockOnPlayPause = jest.fn();
+  const mockOnSpeedChange = jest.fn();
+
+  beforeEach(() => {
+    mockOnStepChange.mockClear();
+    mockOnPlayPause.mockClear();
+    mockOnSpeedChange.mockClear();
+  });
+
+  it('renders with initial values', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    expect(screen.getByText('Step 5/10')).toBeInTheDocument();
+    expect(screen.getByLabelText('Play')).toBeInTheDocument();
+  });
+
+  it('renders with initial values at step 0', () => {
+    render(
+      <TimelinePlayer
+        currentStep={0}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    expect(screen.getByText('Step 0/10')).toBeInTheDocument();
+  });
+
+  it('renders with initial values at max step', () => {
+    render(
+      <TimelinePlayer
+        currentStep={10}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    expect(screen.getByText('Step 10/10')).toBeInTheDocument();
+  });
+
+  it('shows pause button when playing', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={true}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    expect(screen.getByLabelText('Pause')).toBeInTheDocument();
+  });
+
+  it('shows play button when paused', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    expect(screen.getByLabelText('Play')).toBeInTheDocument();
+  });
+
+  it('toggles play/pause when play button is clicked', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const playButton = screen.getByLabelText('Play');
+    fireEvent.click(playButton);
+
+    expect(mockOnPlayPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles play/pause when pause button is clicked', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={true}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const pauseButton = screen.getByLabelText('Pause');
+    fireEvent.click(pauseButton);
+
+    expect(mockOnPlayPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('steps backward when previous button is clicked', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const prevButton = screen.getByLabelText('Previous step');
+    fireEvent.click(prevButton);
+
+    expect(mockOnStepChange).toHaveBeenCalledWith(4);
+  });
+
+  it('steps forward when next button is clicked', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const nextButton = screen.getByLabelText('Next step');
+    fireEvent.click(nextButton);
+
+    expect(mockOnStepChange).toHaveBeenCalledWith(6);
+  });
+
+  it('does not trigger onStepChange when clicking disabled previous button at step 0', () => {
+    render(
+      <TimelinePlayer
+        currentStep={0}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const prevButton = screen.getByLabelText('Previous step');
+    fireEvent.click(prevButton);
+
+    expect(mockOnStepChange).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger onStepChange when clicking disabled next button at max step', () => {
+    render(
+      <TimelinePlayer
+        currentStep={10}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const nextButton = screen.getByLabelText('Next step');
+    fireEvent.click(nextButton);
+
+    expect(mockOnStepChange).not.toHaveBeenCalled();
+  });
+
+  it('disables previous button at step 0', () => {
+    render(
+      <TimelinePlayer
+        currentStep={0}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const prevButton = screen.getByLabelText('Previous step');
+    expect(prevButton).toBeDisabled();
+  });
+
+  it('disables next button at max step', () => {
+    render(
+      <TimelinePlayer
+        currentStep={10}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const nextButton = screen.getByLabelText('Next step');
+    expect(nextButton).toBeDisabled();
+  });
+
+  it('enables previous button when step > 0', () => {
+    render(
+      <TimelinePlayer
+        currentStep={1}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const prevButton = screen.getByLabelText('Previous step');
+    expect(prevButton).not.toBeDisabled();
+  });
+
+  it('enables next button when step < max step', () => {
+    render(
+      <TimelinePlayer
+        currentStep={9}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const nextButton = screen.getByLabelText('Next step');
+    expect(nextButton).not.toBeDisabled();
+  });
+
+  it('updates currentStep when slider value changes', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '7' } });
+
+    expect(mockOnStepChange).toHaveBeenCalledWith(7);
+  });
+
+  it('renders slider with correct min, max, and value attributes', () => {
+    render(
+      <TimelinePlayer
+        currentStep={3}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('min', '0');
+    expect(slider).toHaveAttribute('max', '10');
+    expect(slider).toHaveAttribute('value', '3');
+  });
+
+  it('renders speed selector when onSpeedChange is provided', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={1}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    expect(screen.getByText('0.5x')).toBeInTheDocument();
+    expect(screen.getByText('1x')).toBeInTheDocument();
+    expect(screen.getByText('2x')).toBeInTheDocument();
+  });
+
+  it('does not render speed selector when onSpeedChange is not provided', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    expect(screen.queryByText('0.5x')).not.toBeInTheDocument();
+    expect(screen.queryByText('1x')).not.toBeInTheDocument();
+    expect(screen.queryByText('2x')).not.toBeInTheDocument();
+  });
+
+  it('calls onSpeedChange when speed button is clicked', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={1}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    const speed05Button = screen.getByText('0.5x');
+    fireEvent.click(speed05Button);
+
+    expect(mockOnSpeedChange).toHaveBeenCalledWith(0.5);
+  });
+
+  it('calls onSpeedChange with correct speed values', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={1}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('0.5x'));
+    expect(mockOnSpeedChange).toHaveBeenCalledWith(0.5);
+
+    fireEvent.click(screen.getByText('2x'));
+    expect(mockOnSpeedChange).toHaveBeenCalledWith(2);
+  });
+
+  it('highlights the active speed button', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={2}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    const speed2Button = screen.getByText('2x');
+    expect(speed2Button).toHaveClass('bg-[#722F37]', 'text-white');
+  });
+
+  it('triggers play/pause on space key press', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: ' ' });
+
+    expect(mockOnPlayPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers step backward on ArrowLeft key press', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+
+    expect(mockOnStepChange).toHaveBeenCalledWith(4);
+  });
+
+  it('triggers step forward on ArrowRight key press', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    expect(mockOnStepChange).toHaveBeenCalledWith(6);
+  });
+
+  it('changes speed to 0.5x on key press 1', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={1}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: '1' });
+
+    expect(mockOnSpeedChange).toHaveBeenCalledWith(0.5);
+  });
+
+  it('changes speed to 1x on key press 2', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={0.5}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: '2' });
+
+    expect(mockOnSpeedChange).toHaveBeenCalledWith(1);
+  });
+
+  it('changes speed to 2x on key press 3', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={1}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: '3' });
+
+    expect(mockOnSpeedChange).toHaveBeenCalledWith(2);
+  });
+
+  it('does not trigger keyboard shortcuts when typing in input', () => {
+    render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+      />
+    );
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    fireEvent.keyDown(input, { key: ' ' });
+
+    expect(mockOnPlayPause).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it('matches snapshot when paused', () => {
+    const { container } = render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={false}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={1}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot when playing', () => {
+    const { container } = render(
+      <TimelinePlayer
+        currentStep={5}
+        maxStep={10}
+        isPlaying={true}
+        onStepChange={mockOnStepChange}
+        onPlayPause={mockOnPlayPause}
+        playbackSpeed={2}
+        onSpeedChange={mockOnSpeedChange}
+      />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/graph/__snapshots__/GraphSkeleton.test.tsx.snap
+++ b/frontend/src/__tests__/graph/__snapshots__/GraphSkeleton.test.tsx.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GraphSkeleton matches snapshot 1`] = `
+<div
+  class="w-full h-full flex flex-col items-center justify-center bg-neutral-50/50 relative overflow-hidden rounded-lg border border-neutral-200"
+>
+  <div
+    class="absolute inset-0 opacity-10"
+    style="background-size: 20px 20px;"
+  />
+  <div
+    class="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-shimmer"
+    style="transform: skewX(-20deg);"
+  />
+  <div
+    class="relative z-10 w-3/4 h-3/4 flex items-center justify-center"
+  >
+    <div
+      class="grid grid-cols-3 gap-12 opacity-30"
+    >
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 0ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 100ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 200ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 300ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 400ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 500ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 600ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 700ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center gap-2 animate-pulse"
+        style="animation-delay: 800ms;"
+      >
+        <div
+          class="w-12 h-12 rounded-full bg-[#722F37]/20 border-2 border-[#722F37]/40"
+        />
+        <div
+          class="w-16 h-2 rounded bg-[#722F37]/10"
+        />
+      </div>
+    </div>
+    <svg
+      class="absolute inset-0 w-full h-full pointer-events-none opacity-20"
+    >
+      <path
+        d="M100,100 L200,200 M300,100 L200,200 M100,300 L200,200 M300,300 L200,200"
+        fill="none"
+        stroke="#722F37"
+        stroke-width="2"
+      />
+    </svg>
+  </div>
+  <div
+    class="absolute bottom-8 flex flex-col items-center gap-2"
+  >
+    <div
+      class="text-[#722F37] font-medium text-lg animate-pulse"
+    >
+      Decanting your graph...
+    </div>
+    <div
+      class="flex gap-1"
+    >
+      <div
+        class="w-2 h-2 rounded-full bg-[#722F37] animate-bounce"
+        style="animation-delay: 0ms;"
+      />
+      <div
+        class="w-2 h-2 rounded-full bg-[#722F37] animate-bounce"
+        style="animation-delay: 150ms;"
+      />
+      <div
+        class="w-2 h-2 rounded-full bg-[#722F37] animate-bounce"
+        style="animation-delay: 300ms;"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/__tests__/graph/__snapshots__/ModeIndicatorBadge.test.tsx.snap
+++ b/frontend/src/__tests__/graph/__snapshots__/ModeIndicatorBadge.test.tsx.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModeIndicatorBadge matches snapshot for full_techniques mode 1`] = `
+<div
+  class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-amber-50 to-yellow-50 border border-amber-200 shadow-sm"
+>
+  <div
+    class="p-1.5 bg-amber-100 rounded-full text-amber-700"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-trophy"
+      fill="none"
+      height="16"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"
+      />
+      <path
+        d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"
+      />
+      <path
+        d="M18 9h1.5a1 1 0 0 0 0-5H18"
+      />
+      <path
+        d="M4 22h16"
+      />
+      <path
+        d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"
+      />
+      <path
+        d="M6 9H4.5a1 1 0 0 1 0-5H6"
+      />
+    </svg>
+  </div>
+  <div
+    class="flex flex-col"
+  >
+    <span
+      class="text-xs font-bold text-amber-800 uppercase tracking-wider"
+    >
+      Grand Tasting
+    </span>
+    <span
+      class="text-xs text-amber-700 font-medium"
+    >
+      Sommelier Masterclass · 75 techniques · ~5min
+    </span>
+  </div>
+</div>
+`;
+
+exports[`ModeIndicatorBadge matches snapshot for six_hats mode 1`] = `
+<div
+  class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-[#F7E7CE]/30 to-[#F7E7CE]/10 border border-[#F7E7CE] shadow-sm"
+>
+  <div
+    class="p-1.5 bg-[#722F37]/10 rounded-full text-[#722F37]"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-wine"
+      fill="none"
+      height="16"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 22h8"
+      />
+      <path
+        d="M7 10h10"
+      />
+      <path
+        d="M12 15v7"
+      />
+      <path
+        d="M12 15a5 5 0 0 0 5-5c0-2-.5-4-2-8H9c-1.5 4-2 6-2 8a5 5 0 0 0 5 5Z"
+      />
+    </svg>
+  </div>
+  <div
+    class="flex flex-col"
+  >
+    <span
+      class="text-xs font-bold text-[#722F37] uppercase tracking-wider"
+    >
+      Standard Tasting
+    </span>
+    <span
+      class="text-xs text-[#722F37]/80 font-medium"
+    >
+      Six Sommeliers · ~2min
+    </span>
+  </div>
+</div>
+`;

--- a/frontend/src/__tests__/graph/__snapshots__/ResultTabs.test.tsx.snap
+++ b/frontend/src/__tests__/graph/__snapshots__/ResultTabs.test.tsx.snap
@@ -1,0 +1,251 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultTabs matches snapshot 1`] = `
+<div
+  class="sticky top-0 z-10 bg-white border-b border-gray-200 mb-6"
+>
+  <div
+    class="flex overflow-x-auto scrollbar-hide"
+  >
+    <button
+      aria-selected="true"
+      class="
+                flex items-center gap-2 px-6 py-4 font-medium text-sm whitespace-nowrap
+                transition-all duration-150 border-b-2
+                flex
+                text-[#722F37] border-[#722F37] bg-[#F7E7CE]/30
+              "
+      role="tab"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-wine"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 22h8"
+        />
+        <path
+          d="M7 10h10"
+        />
+        <path
+          d="M12 15v7"
+        />
+        <path
+          d="M12 15a5 5 0 0 0 5-5c0-2-.5-4-2-8H9c-1.5 4-2 6-2 8a5 5 0 0 0 5 5Z"
+        />
+      </svg>
+      Tasting Notes
+    </button>
+    <button
+      aria-selected="false"
+      class="
+                flex items-center gap-2 px-6 py-4 font-medium text-sm whitespace-nowrap
+                transition-all duration-150 border-b-2
+                flex
+                text-gray-600 border-transparent hover:text-[#722F37] hover:bg-gray-50
+              "
+      role="tab"
+      tabindex="-1"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-chart-column"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3 3v16a2 2 0 0 0 2 2h16"
+        />
+        <path
+          d="M18 17V9"
+        />
+        <path
+          d="M13 17V5"
+        />
+        <path
+          d="M8 17v-3"
+        />
+      </svg>
+      2D Graph
+    </button>
+    <button
+      aria-selected="false"
+      class="
+                flex items-center gap-2 px-6 py-4 font-medium text-sm whitespace-nowrap
+                transition-all duration-150 border-b-2
+                hidden md:flex
+                text-gray-600 border-transparent hover:text-[#722F37] hover:bg-gray-50
+              "
+      role="tab"
+      tabindex="-1"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-box"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"
+        />
+        <path
+          d="m3.3 7 8.7 5 8.7-5"
+        />
+        <path
+          d="M12 22V12"
+        />
+      </svg>
+      3D Graph
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ResultTabs matches snapshot with graph-2d active 1`] = `
+<div
+  class="sticky top-0 z-10 bg-white border-b border-gray-200 mb-6"
+>
+  <div
+    class="flex overflow-x-auto scrollbar-hide"
+  >
+    <button
+      aria-selected="false"
+      class="
+                flex items-center gap-2 px-6 py-4 font-medium text-sm whitespace-nowrap
+                transition-all duration-150 border-b-2
+                flex
+                text-gray-600 border-transparent hover:text-[#722F37] hover:bg-gray-50
+              "
+      role="tab"
+      tabindex="-1"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-wine"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 22h8"
+        />
+        <path
+          d="M7 10h10"
+        />
+        <path
+          d="M12 15v7"
+        />
+        <path
+          d="M12 15a5 5 0 0 0 5-5c0-2-.5-4-2-8H9c-1.5 4-2 6-2 8a5 5 0 0 0 5 5Z"
+        />
+      </svg>
+      Tasting Notes
+    </button>
+    <button
+      aria-selected="true"
+      class="
+                flex items-center gap-2 px-6 py-4 font-medium text-sm whitespace-nowrap
+                transition-all duration-150 border-b-2
+                flex
+                text-[#722F37] border-[#722F37] bg-[#F7E7CE]/30
+              "
+      role="tab"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-chart-column"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3 3v16a2 2 0 0 0 2 2h16"
+        />
+        <path
+          d="M18 17V9"
+        />
+        <path
+          d="M13 17V5"
+        />
+        <path
+          d="M8 17v-3"
+        />
+      </svg>
+      2D Graph
+    </button>
+    <button
+      aria-selected="false"
+      class="
+                flex items-center gap-2 px-6 py-4 font-medium text-sm whitespace-nowrap
+                transition-all duration-150 border-b-2
+                hidden md:flex
+                text-gray-600 border-transparent hover:text-[#722F37] hover:bg-gray-50
+              "
+      role="tab"
+      tabindex="-1"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-box"
+        fill="none"
+        height="18"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="18"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"
+        />
+        <path
+          d="m3.3 7 8.7 5 8.7-5"
+        />
+        <path
+          d="M12 22V12"
+        />
+      </svg>
+      3D Graph
+    </button>
+  </div>
+</div>
+`;

--- a/frontend/src/__tests__/graph/__snapshots__/TimelinePlayer.test.tsx.snap
+++ b/frontend/src/__tests__/graph/__snapshots__/TimelinePlayer.test.tsx.snap
@@ -1,0 +1,256 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimelinePlayer matches snapshot when paused 1`] = `
+<div
+  class="flex flex-col gap-2 p-4 bg-white border border-[#F7E7CE] rounded-lg shadow-sm w-full max-w-3xl mx-auto"
+>
+  <div
+    class="flex items-center justify-between gap-4"
+  >
+    <div
+      class="flex items-center gap-2"
+    >
+      <button
+        aria-label="Previous step"
+        class="p-2 text-[#722F37] hover:bg-[#F7E7CE]/20 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-chevron-left"
+          fill="none"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m15 18-6-6 6-6"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Play"
+        class="p-3 bg-[#722F37] text-white rounded-full hover:bg-[#5a252c] transition-colors shadow-md"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-play ml-0.5"
+          fill="currentColor"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Next step"
+        class="p-2 text-[#722F37] hover:bg-[#F7E7CE]/20 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-chevron-right"
+          fill="none"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m9 18 6-6-6-6"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="font-mono text-sm font-medium text-[#722F37] min-w-[80px] text-center"
+    >
+      Step 
+      5
+      /
+      10
+    </div>
+    <div
+      class="flex-1 px-2"
+    >
+      <input
+        class="w-full h-2 bg-[#F7E7CE] rounded-lg appearance-none cursor-pointer accent-[#722F37]"
+        max="10"
+        min="0"
+        type="range"
+        value="5"
+      />
+    </div>
+    <div
+      class="flex items-center bg-[#F7E7CE]/30 rounded-lg p-1"
+    >
+      <button
+        class="px-2 py-1 text-xs font-medium rounded transition-colors text-[#722F37] hover:bg-[#F7E7CE]/50"
+      >
+        0.5
+        x
+      </button>
+      <button
+        class="px-2 py-1 text-xs font-medium rounded transition-colors bg-[#722F37] text-white shadow-sm"
+      >
+        1
+        x
+      </button>
+      <button
+        class="px-2 py-1 text-xs font-medium rounded transition-colors text-[#722F37] hover:bg-[#F7E7CE]/50"
+      >
+        2
+        x
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TimelinePlayer matches snapshot when playing 1`] = `
+<div
+  class="flex flex-col gap-2 p-4 bg-white border border-[#F7E7CE] rounded-lg shadow-sm w-full max-w-3xl mx-auto"
+>
+  <div
+    class="flex items-center justify-between gap-4"
+  >
+    <div
+      class="flex items-center gap-2"
+    >
+      <button
+        aria-label="Previous step"
+        class="p-2 text-[#722F37] hover:bg-[#F7E7CE]/20 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-chevron-left"
+          fill="none"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m15 18-6-6 6-6"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Pause"
+        class="p-3 bg-[#722F37] text-white rounded-full hover:bg-[#5a252c] transition-colors shadow-md"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-pause"
+          fill="currentColor"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="18"
+            rx="1"
+            width="5"
+            x="14"
+            y="3"
+          />
+          <rect
+            height="18"
+            rx="1"
+            width="5"
+            x="5"
+            y="3"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Next step"
+        class="p-2 text-[#722F37] hover:bg-[#F7E7CE]/20 rounded-full disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-chevron-right"
+          fill="none"
+          height="20"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m9 18 6-6-6-6"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="font-mono text-sm font-medium text-[#722F37] min-w-[80px] text-center"
+    >
+      Step 
+      5
+      /
+      10
+    </div>
+    <div
+      class="flex-1 px-2"
+    >
+      <input
+        class="w-full h-2 bg-[#F7E7CE] rounded-lg appearance-none cursor-pointer accent-[#722F37]"
+        max="10"
+        min="0"
+        type="range"
+        value="5"
+      />
+    </div>
+    <div
+      class="flex items-center bg-[#F7E7CE]/30 rounded-lg p-1"
+    >
+      <button
+        class="px-2 py-1 text-xs font-medium rounded transition-colors text-[#722F37] hover:bg-[#F7E7CE]/50"
+      >
+        0.5
+        x
+      </button>
+      <button
+        class="px-2 py-1 text-xs font-medium rounded transition-colors text-[#722F37] hover:bg-[#F7E7CE]/50"
+      >
+        1
+        x
+      </button>
+      <button
+        class="px-2 py-1 text-xs font-medium rounded transition-colors bg-[#722F37] text-white shadow-sm"
+      >
+        2
+        x
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/__tests__/graph/types.test.ts
+++ b/frontend/src/__tests__/graph/types.test.ts
@@ -1,0 +1,409 @@
+import {
+  isReactFlowNode,
+  isReactFlowGraph,
+  isGraph3DPayload,
+  isTraceEvent,
+  ReactFlowNode,
+  ReactFlowGraph,
+  Graph3DPayload,
+  TraceEvent,
+} from '@/types/graph';
+
+describe('Type Guards', () => {
+  describe('isReactFlowNode', () => {
+    it('returns true for a valid ReactFlowNode', () => {
+      const validNode: ReactFlowNode = {
+        id: 'node-1',
+        type: 'agent',
+        position: { x: 100, y: 200 },
+        data: { label: 'Test Node' },
+      };
+      expect(isReactFlowNode(validNode)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isReactFlowNode(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isReactFlowNode(undefined)).toBe(false);
+    });
+
+    it('returns false for a string', () => {
+      expect(isReactFlowNode('not a node')).toBe(false);
+    });
+
+    it('returns false for a number', () => {
+      expect(isReactFlowNode(123)).toBe(false);
+    });
+
+    it('returns false when id is missing', () => {
+      const invalidNode = {
+        type: 'agent',
+        position: { x: 100, y: 200 },
+        data: { label: 'Test Node' },
+      };
+      expect(isReactFlowNode(invalidNode)).toBe(false);
+    });
+
+    it('returns false when type is not a string', () => {
+      const invalidNode = {
+        id: 'node-1',
+        type: 123,
+        position: { x: 100, y: 200 },
+        data: { label: 'Test Node' },
+      };
+      expect(isReactFlowNode(invalidNode)).toBe(false);
+    });
+
+    it('returns false when position is missing', () => {
+      const invalidNode = {
+        id: 'node-1',
+        type: 'agent',
+        data: { label: 'Test Node' },
+      };
+      expect(isReactFlowNode(invalidNode)).toBe(false);
+    });
+
+    it('returns false when position.x is not a number', () => {
+      const invalidNode = {
+        id: 'node-1',
+        type: 'agent',
+        position: { x: '100', y: 200 },
+        data: { label: 'Test Node' },
+      };
+      expect(isReactFlowNode(invalidNode)).toBe(false);
+    });
+
+    it('returns false when position.y is not a number', () => {
+      const invalidNode = {
+        id: 'node-1',
+        type: 'agent',
+        position: { x: 100, y: '200' },
+        data: { label: 'Test Node' },
+      };
+      expect(isReactFlowNode(invalidNode)).toBe(false);
+    });
+
+    it('returns false when data is null', () => {
+      const invalidNode = {
+        id: 'node-1',
+        type: 'agent',
+        position: { x: 100, y: 200 },
+        data: null,
+      };
+      expect(isReactFlowNode(invalidNode)).toBe(false);
+    });
+
+    it('returns false for an empty object', () => {
+      expect(isReactFlowNode({})).toBe(false);
+    });
+  });
+
+  describe('isReactFlowGraph', () => {
+    it('returns true for a valid ReactFlowGraph', () => {
+      const validGraph: ReactFlowGraph = {
+        graph_schema_version: 2,
+        mode: 'six_hats',
+        nodes: [
+          {
+            id: 'node-1',
+            type: 'agent',
+            position: { x: 100, y: 200 },
+            data: { label: 'Test Node' },
+          },
+        ],
+        edges: [
+          {
+            id: 'edge-1',
+            source: 'node-1',
+            target: 'node-2',
+          },
+        ],
+      };
+      expect(isReactFlowGraph(validGraph)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isReactFlowGraph(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isReactFlowGraph(undefined)).toBe(false);
+    });
+
+    it('returns false when graph_schema_version is not a number', () => {
+      const invalidGraph = {
+        graph_schema_version: '2',
+        mode: 'six_hats',
+        nodes: [],
+        edges: [],
+      };
+      expect(isReactFlowGraph(invalidGraph)).toBe(false);
+    });
+
+    it('returns false when mode is not a string', () => {
+      const invalidGraph = {
+        graph_schema_version: 2,
+        mode: 123,
+        nodes: [],
+        edges: [],
+      };
+      expect(isReactFlowGraph(invalidGraph)).toBe(false);
+    });
+
+    it('returns false when nodes is not an array', () => {
+      const invalidGraph = {
+        graph_schema_version: 2,
+        mode: 'six_hats',
+        nodes: 'not an array',
+        edges: [],
+      };
+      expect(isReactFlowGraph(invalidGraph)).toBe(false);
+    });
+
+    it('returns false when edges is not an array', () => {
+      const invalidGraph = {
+        graph_schema_version: 2,
+        mode: 'six_hats',
+        nodes: [],
+        edges: 'not an array',
+      };
+      expect(isReactFlowGraph(invalidGraph)).toBe(false);
+    });
+
+    it('returns false for an empty object', () => {
+      expect(isReactFlowGraph({})).toBe(false);
+    });
+
+    it('returns true for graph with empty arrays', () => {
+      const graph = {
+        graph_schema_version: 2,
+        mode: 'six_hats',
+        nodes: [],
+        edges: [],
+      };
+      expect(isReactFlowGraph(graph)).toBe(true);
+    });
+  });
+
+  describe('isGraph3DPayload', () => {
+    it('returns true for a valid Graph3DPayload', () => {
+      const validPayload: Graph3DPayload = {
+        graph_schema_version: 2,
+        evaluation_id: 'eval-123',
+        mode: 'full_techniques',
+        nodes: [
+          {
+            node_id: 'node-1',
+            node_type: 'agent',
+            label: 'Test Node',
+            position: { x: 0, y: 0, z: 0 },
+            step_number: 1,
+          },
+        ],
+        edges: [
+          {
+            edge_id: 'edge-1',
+            source: 'node-1',
+            target: 'node-2',
+            edge_type: 'flow',
+            width: 2,
+            step_number: 1,
+          },
+        ],
+        metadata: {
+          x_range: [-10, 10],
+          y_range: [-10, 10],
+          z_range: [0, 5],
+          total_nodes: 1,
+          total_edges: 1,
+          total_steps: 1,
+          max_step_number: 1,
+          graph_schema_version: 2,
+          generated_at: '2024-01-01T00:00:00Z',
+        },
+      };
+      expect(isGraph3DPayload(validPayload)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isGraph3DPayload(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isGraph3DPayload(undefined)).toBe(false);
+    });
+
+    it('returns false when evaluation_id is missing', () => {
+      const invalidPayload = {
+        graph_schema_version: 2,
+        mode: 'full_techniques',
+        nodes: [],
+        edges: [],
+        metadata: {},
+      };
+      expect(isGraph3DPayload(invalidPayload)).toBe(false);
+    });
+
+    it('returns false when evaluation_id is not a string', () => {
+      const invalidPayload = {
+        graph_schema_version: 2,
+        evaluation_id: 123,
+        mode: 'full_techniques',
+        nodes: [],
+        edges: [],
+        metadata: {},
+      };
+      expect(isGraph3DPayload(invalidPayload)).toBe(false);
+    });
+
+    it('returns false when nodes is not an array', () => {
+      const invalidPayload = {
+        graph_schema_version: 2,
+        evaluation_id: 'eval-123',
+        mode: 'full_techniques',
+        nodes: 'not an array',
+        edges: [],
+        metadata: {},
+      };
+      expect(isGraph3DPayload(invalidPayload)).toBe(false);
+    });
+
+    it('returns false when edges is not an array', () => {
+      const invalidPayload = {
+        graph_schema_version: 2,
+        evaluation_id: 'eval-123',
+        mode: 'full_techniques',
+        nodes: [],
+        edges: 'not an array',
+        metadata: {},
+      };
+      expect(isGraph3DPayload(invalidPayload)).toBe(false);
+    });
+
+    it('returns false when metadata is null', () => {
+      const invalidPayload = {
+        graph_schema_version: 2,
+        evaluation_id: 'eval-123',
+        mode: 'full_techniques',
+        nodes: [],
+        edges: [],
+        metadata: null,
+      };
+      expect(isGraph3DPayload(invalidPayload)).toBe(false);
+    });
+
+    it('returns false when metadata is missing', () => {
+      const invalidPayload = {
+        graph_schema_version: 2,
+        evaluation_id: 'eval-123',
+        mode: 'full_techniques',
+        nodes: [],
+        edges: [],
+      };
+      expect(isGraph3DPayload(invalidPayload)).toBe(false);
+    });
+
+    it('returns false for an empty object', () => {
+      expect(isGraph3DPayload({})).toBe(false);
+    });
+  });
+
+  describe('isTraceEvent', () => {
+    it('returns true for a valid TraceEvent', () => {
+      const validEvent: TraceEvent = {
+        step: 1,
+        timestamp: '2024-01-01T00:00:00Z',
+        agent: 'Marcel',
+        technique_id: 'tech-1',
+        action: 'started',
+      };
+      expect(isTraceEvent(validEvent)).toBe(true);
+    });
+
+    it('returns true for a TraceEvent with optional fields', () => {
+      const validEvent: TraceEvent = {
+        step: 1,
+        timestamp: '2024-01-01T00:00:00Z',
+        agent: 'Marcel',
+        technique_id: 'tech-1',
+        action: 'completed',
+        item_id: 'item-123',
+        score_delta: 5,
+        evidence_ref: 'evidence-456',
+      };
+      expect(isTraceEvent(validEvent)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isTraceEvent(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isTraceEvent(undefined)).toBe(false);
+    });
+
+    it('returns false when step is not a number', () => {
+      const invalidEvent = {
+        step: '1',
+        timestamp: '2024-01-01T00:00:00Z',
+        agent: 'Marcel',
+        technique_id: 'tech-1',
+        action: 'started',
+      };
+      expect(isTraceEvent(invalidEvent)).toBe(false);
+    });
+
+    it('returns false when timestamp is not a string', () => {
+      const invalidEvent = {
+        step: 1,
+        timestamp: 1234567890,
+        agent: 'Marcel',
+        technique_id: 'tech-1',
+        action: 'started',
+      };
+      expect(isTraceEvent(invalidEvent)).toBe(false);
+    });
+
+    it('returns false when agent is missing', () => {
+      const invalidEvent = {
+        step: 1,
+        timestamp: '2024-01-01T00:00:00Z',
+        technique_id: 'tech-1',
+        action: 'started',
+      };
+      expect(isTraceEvent(invalidEvent)).toBe(false);
+    });
+
+    it('returns false when technique_id is not a string', () => {
+      const invalidEvent = {
+        step: 1,
+        timestamp: '2024-01-01T00:00:00Z',
+        agent: 'Marcel',
+        technique_id: 123,
+        action: 'started',
+      };
+      expect(isTraceEvent(invalidEvent)).toBe(false);
+    });
+
+    it('returns false when action is not a string', () => {
+      const invalidEvent = {
+        step: 1,
+        timestamp: '2024-01-01T00:00:00Z',
+        agent: 'Marcel',
+        technique_id: 'tech-1',
+        action: 123,
+      };
+      expect(isTraceEvent(invalidEvent)).toBe(false);
+    });
+
+    it('returns false for an empty object', () => {
+      expect(isTraceEvent({})).toBe(false);
+    });
+
+    it('returns false for an array', () => {
+      expect(isTraceEvent([])).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add Jest configuration with jsdom environment and TypeScript support
- Create comprehensive test suite for graph visualization components
- 114 tests passing with 7 snapshot tests

## Test Coverage

| File | Description | Tests |
|------|-------------|-------|
| `types.test.ts` | Type guard validation | 30 tests |
| `ResultTabs.test.tsx` | Tab navigation, keyboard, hash sync | 16 tests |
| `TimelinePlayer.test.tsx` | Play controls, slider, speed selector | 37 tests |
| `ModeIndicatorBadge.test.tsx` | Mode display, styling | 12 tests |
| `GraphSkeleton.test.tsx` | Loading skeleton UI | 11 tests |

## Test Categories
- **Unit Tests**: Type guards, component props, state management
- **Snapshot Tests**: UI consistency for all major components
- **Integration Tests**: Tab switching, keyboard navigation, URL hash sync

## Files Added
| File | Description |
|------|-------------|
| `jest.config.js` | Jest config with jsdom, path mapping |
| `jest.setup.ts` | Test setup with jest-dom matchers |
| `src/__tests__/graph/*.test.{ts,tsx}` | 5 test files |
| `src/__tests__/graph/__snapshots__/*.snap` | 4 snapshot files |

## Closes
- Closes #173

## Testing
```bash
cd frontend && npm test -- --testPathPattern="graph"
# 114 passing tests, 7 snapshots
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 그래프 관련 컴포넌트(GraphSkeleton, ModeIndicatorBadge, ResultTabs, TimelinePlayer)에 대한 종합적인 단위 테스트 스위트 추가
  * 타입 가드 함수의 신뢰성을 검증하는 테스트 추가
  * Jest 테스팅 인프라 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->