### PR TITLE
fix: add missing shimmer animation for GraphSkeleton

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -42,3 +42,12 @@ body {
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+@keyframes shimmer {
+  0% { transform: translateX(-100%) skewX(-20deg); }
+  100% { transform: translateX(200%) skewX(-20deg); }
+}
+
+.animate-shimmer {
+  animation: shimmer 2s infinite;
+}


### PR DESCRIPTION
## Problem
The `GraphSkeleton` component uses `animate-shimmer` class but the corresponding CSS keyframe animation was not defined in `globals.css`, causing the shimmer effect to not work.

## Solution
Added the missing `@keyframes shimmer` animation and `.animate-shimmer` class to `globals.css`.

## Changes
```css
@keyframes shimmer {
  0% { transform: translateX(-100%) skewX(-20deg); }
  100% { transform: translateX(200%) skewX(-20deg); }
}

.animate-shimmer {
  animation: shimmer 2s infinite;
}
```

## Testing
- `npm run build` passes
- Visual verification via Playwright browser testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 새로운 shimmer 애니메이션 효과가 추가되었습니다. 사용자 인터페이스에 부드러운 광선 효과를 통해 시각적 피드백을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->