### PR TITLE
fix: resolve frontend test failures

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/', '<rootDir>/e2e/'],
   transform: {
     '^.+\\.(ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
   },

--- a/frontend/src/__tests__/integration.test.tsx
+++ b/frontend/src/__tests__/integration.test.tsx
@@ -39,9 +39,10 @@ describe('Repository Selection Flow Integration', () => {
     });
 
     it('shows selected state when isSelected is true', () => {
-      render(<RepositoryCard repository={mockRepository} isSelected={true} />);
+      const { container } = render(<RepositoryCard repository={mockRepository} isSelected={true} />);
 
-      const card = screen.getByText('test-repo').closest('div');
+      // The outer wrapper div has the border class
+      const card = container.firstChild as HTMLElement;
       expect(card).toHaveClass('border-[#722F37]');
     });
   });
@@ -114,11 +115,12 @@ describe('Repository Selection Flow Integration', () => {
 
     it('shows error state with retry button', () => {
       const onRefresh = jest.fn();
+      const error = new Error('Failed to load repositories');
       render(
         <RepositoryPicker
           repositories={[]}
           isLoading={false}
-          error="Failed to load repositories"
+          error={error}
           onSelect={jest.fn()}
           onRefresh={onRefresh}
         />


### PR DESCRIPTION
## Summary
- Fix 2 failing tests in `integration.test.tsx` 
- Configure Jest to properly exclude Playwright e2e tests

## Changes
1. **RepositoryCard test**: Fixed element query - now correctly finds outer wrapper div with `border-[#722F37]` class
2. **RepositoryPicker test**: Fixed error prop - pass `Error` object instead of string (component uses `error.message`)
3. **Jest config**: Added `<rootDir>/e2e/` to `testPathIgnorePatterns` to prevent Jest from trying to run Playwright tests

## Test Results
```
Test Suites: 6 passed, 6 total
Tests:       123 passed, 123 total
Snapshots:   7 passed, 7 total
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 실행 범위 조정으로 특정 디렉토리가 테스트 대상에서 제외되었습니다.
  * 통합 테스트가 업데이트되어 더 정확한 요소 선택 및 에러 처리 방식으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->