### PR TITLE
fix(a11y): add ARIA roles and keyboard navigation to CriteriaSelector

### DIFF
--- a/frontend/src/components/CriteriaSelector.tsx
+++ b/frontend/src/components/CriteriaSelector.tsx
@@ -35,15 +35,30 @@ const criteriaOptions: { value: CriteriaType; label: string; description: string
 ];
 
 export const CriteriaSelector: React.FC<CriteriaSelectorProps> = ({ value, onChange }) => {
+  const handleKeyDown = (e: React.KeyboardEvent, optionValue: CriteriaType) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onChange(optionValue);
+    }
+  };
+
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-[#722F37]">Select Your Blend</h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <h3 id="criteria-label" className="text-lg font-semibold text-[#722F37]">Select Your Blend</h3>
+      <div 
+        role="radiogroup" 
+        aria-labelledby="criteria-label"
+        className="grid grid-cols-1 md:grid-cols-2 gap-4"
+      >
         {criteriaOptions.map((option) => (
           <div
             key={option.value}
+            role="radio"
+            aria-checked={value === option.value}
+            tabIndex={0}
             onClick={() => onChange(option.value)}
-            className={`cursor-pointer border-2 rounded-lg p-4 transition-all duration-200 flex items-start space-x-3 ${
+            onKeyDown={(e) => handleKeyDown(e, option.value)}
+            className={`cursor-pointer border-2 rounded-lg p-4 transition-all duration-200 flex items-start space-x-3 focus:outline-none focus:ring-2 focus:ring-[#722F37] focus:ring-offset-2 ${
               value === option.value
                 ? 'border-[#722F37] bg-[#F7E7CE] bg-opacity-30'
                 : 'border-gray-200 hover:border-[#722F37] hover:bg-gray-50'


### PR DESCRIPTION
## Summary
- Improve accessibility of the Blend/Criteria selector on the Evaluate page

## Changes
The CriteriaSelector component was missing proper ARIA attributes for screen readers and keyboard navigation.

### Added:
- `role="radiogroup"` on container with `aria-labelledby` pointing to heading
- `role="radio"` with `aria-checked` on each option
- `tabIndex={0}` for keyboard focus
- `onKeyDown` handler for Enter/Space key activation
- Focus ring styles (`focus:ring-2`) for keyboard navigation visibility

### Before (accessibility tree):
```
- generic [cursor=pointer]:
  - heading "House Blend (Basic)"
```

### After (accessibility tree):
```
- radiogroup "Select Your Blend":
  - radio "House Blend (Basic)..." [checked]
  - radio "Beaujolais Nouveau (Hackathon)..."
  - radio "Grand Cru (Academic)..."
  - radio "Sommelier's Choice (Custom)..."
```

## Testing
- ✅ All 123 Jest tests pass
- ✅ Verified with Playwright that `aria-checked` updates correctly on selection
- ✅ Keyboard navigation works (Tab to focus, Enter/Space to select)