### PR TITLE
feat(2d): add InteractiveGraphView and custom node components (#205, #206)

### DIFF
--- a/frontend/src/components/graph/nodes/HatNode.tsx
+++ b/frontend/src/components/graph/nodes/HatNode.tsx
@@ -1,0 +1,49 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+import { cn } from '@/lib/utils';
+
+const HAT_COLORS: Record<string, { bg: string; border: string; text: string }> = {
+  white: { bg: '#FFFFFF', border: '#E5E7EB', text: '#374151' },
+  red: { bg: '#DC2626', border: '#B91C1C', text: '#FFFFFF' },
+  black: { bg: '#1F2937', border: '#111827', text: '#FFFFFF' },
+  yellow: { bg: '#FBBF24', border: '#D97706', text: '#1F2937' },
+  green: { bg: '#16A34A', border: '#15803D', text: '#FFFFFF' },
+  blue: { bg: '#2563EB', border: '#1D4ED8', text: '#FFFFFF' },
+};
+
+const HatNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  const hatType = (data.hatType as string)?.toLowerCase() || 'white';
+  const colors = HAT_COLORS[hatType] || HAT_COLORS.white;
+  const isFuture = data.isFuture;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center transition-all duration-300',
+        isFuture && 'opacity-40 grayscale'
+      )}
+    >
+      <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-gray-400" />
+
+      <div
+        className="w-16 h-16 rounded-full flex items-center justify-center shadow-md border-2 font-bold text-xs uppercase tracking-wider"
+        style={{
+          backgroundColor: colors.bg,
+          borderColor: colors.border,
+          color: colors.text,
+        }}
+      >
+        {hatType.slice(0, 3)}
+      </div>
+
+      <div className="mt-2 text-sm font-medium text-gray-700 max-w-[120px] text-center truncate">
+        {data.label}
+      </div>
+
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3 !bg-gray-400" />
+    </div>
+  );
+};
+
+export default memo(HatNode);

--- a/frontend/src/components/graph/nodes/ItemNode.tsx
+++ b/frontend/src/components/graph/nodes/ItemNode.tsx
@@ -1,0 +1,52 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+import { Package } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const BMAD_COLORS: Record<string, { bg: string; border: string }> = {
+  A: { bg: '#DBEAFE', border: '#3B82F6' },
+  B: { bg: '#DCFCE7', border: '#22C55E' },
+  C: { bg: '#FEF9C3', border: '#EAB308' },
+  D: { bg: '#FEE2E2', border: '#EF4444' },
+};
+
+const ItemNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  const category = ((data.category as string) || 'A').toUpperCase().charAt(0);
+  const colors = BMAD_COLORS[category] || BMAD_COLORS.A;
+  const isFuture = data.isFuture;
+
+  return (
+    <div
+      className={cn(
+        'w-48 rounded-lg shadow-sm border overflow-hidden transition-all duration-300',
+        isFuture && 'opacity-40 grayscale'
+      )}
+      style={{
+        backgroundColor: colors.bg,
+        borderColor: colors.border,
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-gray-400" />
+
+      <div className="p-3 flex items-start space-x-2">
+        <div
+          className="w-8 h-8 rounded flex items-center justify-center flex-shrink-0"
+          style={{ backgroundColor: colors.border }}
+        >
+          <Package size={16} className="text-white" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h4 className="font-medium text-gray-900 text-sm truncate" title={data.label as string}>
+            {data.label}
+          </h4>
+          <span className="text-xs text-gray-600">Category {category}</span>
+        </div>
+      </div>
+
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3 !bg-gray-400" />
+    </div>
+  );
+};
+
+export default memo(ItemNode);

--- a/frontend/src/components/graph/nodes/ProcessNode.tsx
+++ b/frontend/src/components/graph/nodes/ProcessNode.tsx
@@ -1,0 +1,41 @@
+import React, { memo } from 'react';
+import { Handle, Position, NodeProps, Node } from '@xyflow/react';
+import { ReactFlowNodeData } from '@/types/graph';
+import { Cog } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const ProcessNode = ({ data }: NodeProps<Node<ReactFlowNodeData>>) => {
+  const isFuture = data.isFuture;
+  const stepNumber = data.step as number | undefined;
+
+  return (
+    <div
+      className={cn(
+        'w-44 bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden transition-all duration-300',
+        isFuture && 'opacity-40 grayscale'
+      )}
+    >
+      <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-gray-400" />
+
+      <div className="p-3 border-l-4 border-[#722F37]">
+        <div className="flex items-start space-x-2">
+          <div className="w-8 h-8 rounded bg-[#722F37]/10 flex items-center justify-center flex-shrink-0">
+            <Cog size={16} className="text-[#722F37]" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h4 className="font-medium text-gray-900 text-sm leading-tight truncate" title={data.label as string}>
+              {data.label}
+            </h4>
+            {stepNumber !== undefined && (
+              <span className="text-xs text-gray-500">Step {stepNumber}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Handle type="source" position={Position.Bottom} className="w-3 h-3 !bg-gray-400" />
+    </div>
+  );
+};
+
+export default memo(ProcessNode);

--- a/frontend/src/components/graph/nodes/index.ts
+++ b/frontend/src/components/graph/nodes/index.ts
@@ -4,6 +4,9 @@ import AgentNode from './AgentNode';
 import TechniqueNode from './TechniqueNode';
 import SynthesisNode from './SynthesisNode';
 import RagNode from './RagNode';
+import HatNode from './HatNode';
+import ItemNode from './ItemNode';
+import ProcessNode from './ProcessNode';
 
 export const nodeTypes = {
   start: StartNode,
@@ -12,5 +15,7 @@ export const nodeTypes = {
   technique: TechniqueNode,
   synthesis: SynthesisNode,
   rag: RagNode,
-  process: TechniqueNode, // Fallback for process nodes
+  hat: HatNode,
+  item: ItemNode,
+  process: ProcessNode,
 };

--- a/frontend/src/components/result/InteractiveGraphView.tsx
+++ b/frontend/src/components/result/InteractiveGraphView.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import React, { useEffect, useCallback, useState, useMemo } from 'react';
+import {
+  ReactFlow,
+  Controls,
+  Background,
+  useNodesState,
+  useEdgesState,
+  Node,
+  Edge,
+  BackgroundVariant,
+  NodeMouseHandler,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { api } from '@/lib/api';
+import { nodeTypes } from './nodes';
+import { getLayoutedElements } from '@/lib/graphLayout';
+import { AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
+import { getAgentColor, getCategoryColor } from '@/lib/graphColors';
+import { GraphEvaluationMode, ReactFlowNodeData } from '@/types/graph';
+import { cn } from '@/lib/utils';
+
+type GraphViewType = 'structure' | 'execution';
+
+interface InteractiveGraphViewProps {
+  evaluationId: string;
+  view: GraphViewType;
+  currentStep?: number;
+  className?: string;
+  onNodeClick?: (nodeId: string, nodeData: ReactFlowNodeData) => void;
+}
+
+interface SelectedNode {
+  id: string;
+  type: string;
+  data: ReactFlowNodeData;
+}
+
+export function InteractiveGraphView({
+  evaluationId,
+  view,
+  currentStep,
+  className,
+  onNodeClick: onNodeClickProp,
+}: InteractiveGraphViewProps) {
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<GraphEvaluationMode | string>('six_hats');
+  const [maxStep, setMaxStep] = useState(0);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const graphData =
+        view === 'structure'
+          ? await api.getGraphStructure(evaluationId)
+          : await api.getGraphExecution(evaluationId);
+
+      setMode(graphData.mode);
+
+      const maxNodeStep = Math.max(
+        ...graphData.nodes.map((n) => (n.data.step as number) || 0),
+        0
+      );
+      setMaxStep(maxNodeStep);
+
+      const initialNodes: Node[] = graphData.nodes.map((node) => {
+        let nodeColor = node.data.color as string;
+
+        if (node.type === 'agent') {
+          if (graphData.mode === 'full_techniques') {
+            nodeColor = getCategoryColor(node.data.category as string);
+          } else {
+            nodeColor = getAgentColor(node.data.label as string);
+          }
+        }
+
+        return {
+          id: node.id,
+          type: node.type,
+          position: node.position || { x: 0, y: 0 },
+          data: {
+            ...node.data,
+            color: nodeColor,
+            mode: graphData.mode,
+          },
+        };
+      });
+
+      const initialEdges: Edge[] = graphData.edges.map((edge) => ({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        animated: view === 'execution',
+        style: {
+          stroke: '#722F37',
+          strokeWidth: 2,
+          strokeDasharray: edge.data?.edge_type === 'secondary' ? '5,5' : undefined,
+        },
+      }));
+
+      const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
+        initialNodes,
+        initialEdges
+      );
+
+      setNodes(layoutedNodes);
+      setEdges(layoutedEdges);
+    } catch (err) {
+      console.error(`Failed to fetch ${view} graph data:`, err);
+      setError(`Failed to load ${view} graph data. Please try again.`);
+    } finally {
+      setLoading(false);
+    }
+  }, [evaluationId, view, setNodes, setEdges]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Step-based visibility: opacity/blur for nodes beyond currentStep
+  useEffect(() => {
+    if (currentStep === undefined) return;
+
+    setNodes((nds) =>
+      nds.map((node) => {
+        const nodeStep = (node.data.step as number) || 0;
+        const isFuture = nodeStep > currentStep;
+        return {
+          ...node,
+          style: {
+            ...node.style,
+            opacity: isFuture ? 0.15 : 1,
+            filter: isFuture ? 'grayscale(100%) blur(1px)' : 'none',
+            transition: 'opacity 0.3s ease, filter 0.3s ease',
+          },
+          data: {
+            ...node.data,
+            isFuture,
+          },
+        };
+      })
+    );
+  }, [currentStep, setNodes]);
+
+  const handleNodeClick: NodeMouseHandler = useCallback(
+    (_event, node) => {
+      if (onNodeClickProp) {
+        onNodeClickProp(node.id, node.data as ReactFlowNodeData);
+      }
+    },
+    [onNodeClickProp]
+  );
+
+  if (loading) {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center bg-gray-50 rounded-lg',
+          className
+        )}
+      >
+        <Loader2 className="w-8 h-8 animate-spin text-[#722F37]" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col items-center justify-center bg-white rounded-lg border border-gray-100',
+          className
+        )}
+      >
+        <AlertCircle className="w-8 h-8 text-red-500 mb-3" />
+        <p className="text-gray-800 font-medium text-sm mb-2">{error}</p>
+        <button
+          onClick={fetchData}
+          className="flex items-center px-3 py-1.5 text-sm bg-[#722F37] text-white rounded-lg hover:bg-[#5D262D] transition-colors"
+        >
+          <RefreshCw size={14} className="mr-1.5" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('bg-[#FAFAFA] rounded-lg overflow-hidden', className)}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={handleNodeClick}
+        nodeTypes={nodeTypes}
+        fitView
+        attributionPosition="bottom-left"
+        minZoom={0.1}
+        maxZoom={1.5}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Controls className="!bg-white !border-gray-200 !shadow-sm" />
+        <Background variant={BackgroundVariant.Dots} gap={12} size={1} color="#E5E7EB" />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/frontend/src/components/result/nodes/index.ts
+++ b/frontend/src/components/result/nodes/index.ts
@@ -1,0 +1,1 @@
+export { nodeTypes } from '@/components/graph/nodes';

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -41,6 +41,10 @@ export interface ReactFlowEdge {
   target: string;
   animated?: boolean;
   style?: Record<string, unknown>;
+  data?: {
+    edge_type?: 'primary' | 'secondary' | 'excluded';
+    weight?: number;
+  };
 }
 
 export interface ReactFlowGraph {


### PR DESCRIPTION
## Summary
Creates InteractiveGraphView component for 2D ReactFlow visualization and adds missing custom node components.

Closes #205
Closes #206

## New Components

### InteractiveGraphView (`result/InteractiveGraphView.tsx`)
- Props: `evaluationId`, `view: 'structure' | 'execution'`, `currentStep?`, `className?`
- Fetches from `api.getGraphStructure` or `api.getGraphExecution` based on view prop
- Renders ReactFlow with custom nodeTypes
- Step-based visibility: opacity/blur for nodes beyond currentStep
- Layout via existing `graphLayout.ts`

### Custom Node Components
- **HatNode**: Six Hats colored circles (white/red/black/yellow/green/blue)
- **ItemNode**: Evaluation item nodes with BMAD colors (A=blue, B=green, C=yellow, D=red)  
- **ProcessNode**: Process step nodes with wine-colored accent

## Type Updates
- Added `data` field to `ReactFlowEdge` for edge styling (edge_type, weight)

## Testing
- [x] Build passes
- [x] 122 tests pass

## Acceptance Criteria
### #205 InteractiveGraphView
- [x] Structure view shows static workflow topology
- [x] Execution view overlays trace data (animated edges)
- [x] Step gating works for timeline sync

### #206 ReactFlow Custom Nodes
- [x] Each node type renders correctly in ReactFlow
- [x] Hat nodes show correct colors
- [x] Item nodes colored by BMAD category