### PR TITLE
test(graph): add WebGL fallback and type guard tests (#211)

### DIFF
--- a/frontend/src/__tests__/graph/webgl.test.ts
+++ b/frontend/src/__tests__/graph/webgl.test.ts
@@ -1,0 +1,101 @@
+import { isWebGLAvailable, useWebGLSupport } from '@/lib/webgl';
+import { renderHook } from '@testing-library/react';
+
+const originalCreateElement = document.createElement.bind(document);
+
+describe('WebGL Detection', () => {
+  describe('isWebGLAvailable', () => {
+    afterEach(() => {
+      document.createElement = originalCreateElement;
+    });
+
+    it('returns true when WebGL2 is available', () => {
+      const mockCanvas = {
+        getContext: jest.fn((type: string) => {
+          if (type === 'webgl2') return {};
+          return null;
+        }),
+      };
+      document.createElement = jest.fn((tag: string) => {
+        if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
+        return originalCreateElement(tag);
+      });
+
+      expect(isWebGLAvailable()).toBe(true);
+      expect(mockCanvas.getContext).toHaveBeenCalledWith('webgl2');
+    });
+
+    it('returns true when only WebGL1 is available', () => {
+      const mockCanvas = {
+        getContext: jest.fn((type: string) => {
+          if (type === 'webgl') return {};
+          return null;
+        }),
+      };
+      document.createElement = jest.fn((tag: string) => {
+        if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
+        return originalCreateElement(tag);
+      });
+
+      expect(isWebGLAvailable()).toBe(true);
+    });
+
+    it('returns false when neither WebGL2 nor WebGL1 is available', () => {
+      const mockCanvas = {
+        getContext: jest.fn(() => null),
+      };
+      document.createElement = jest.fn((tag: string) => {
+        if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
+        return originalCreateElement(tag);
+      });
+
+      expect(isWebGLAvailable()).toBe(false);
+    });
+
+    it('returns false when getContext throws an error', () => {
+      const mockCanvas = {
+        getContext: jest.fn(() => {
+          throw new Error('WebGL not supported');
+        }),
+      };
+      document.createElement = jest.fn((tag: string) => {
+        if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
+        return originalCreateElement(tag);
+      });
+
+      expect(isWebGLAvailable()).toBe(false);
+    });
+  });
+
+  describe('useWebGLSupport', () => {
+    afterEach(() => {
+      document.createElement = originalCreateElement;
+    });
+
+    it('returns true when WebGL is available', () => {
+      const mockCanvas = {
+        getContext: jest.fn(() => ({})),
+      };
+      document.createElement = jest.fn((tag: string) => {
+        if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
+        return originalCreateElement(tag);
+      });
+
+      const { result } = renderHook(() => useWebGLSupport());
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when WebGL is not available', () => {
+      const mockCanvas = {
+        getContext: jest.fn(() => null),
+      };
+      document.createElement = jest.fn((tag: string) => {
+        if (tag === 'canvas') return mockCanvas as unknown as HTMLCanvasElement;
+        return originalCreateElement(tag);
+      });
+
+      const { result } = renderHook(() => useWebGLSupport());
+      expect(result.current).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds comprehensive tests for WebGL detection and type guards as specified in #211.

Closes #211

## New Tests

### `webgl.test.ts`
- `isWebGLAvailable()` tests:
  - Returns true when WebGL2 is available
  - Returns true when only WebGL1 is available
  - Returns false when neither is available
  - Returns false when getContext throws

- `useWebGLSupport()` hook tests:
  - Returns true/false based on WebGL availability

### `types.test.ts` additions
- `Graph3DEdge` with control_points field fixtures
- `Graph3DEdge` with bundled_path field fixtures
- `ExcludedTechnique` type validation
- `Graph3DPayload` with excluded_techniques array
- Type guards remain permissive for extensibility

## Test Results
- Total tests: 137 (up from 122)
- All tests pass
- Build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 그래프 타입 및 WebGL 기능에 대한 포괄적인 단위 테스트를 추가하여 코드 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->