### PR TITLE
feat(frontend): add Google Analytics tracking

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Playfair_Display, Cinzel } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { AuthWrapper } from "@/components/AuthWrapper";
 import { SiteHeader } from "@/components/SiteHeader";
+
+const GA_ID = "G-65HJEVF1M4";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -47,6 +50,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_ID}');
+        `}
+      </Script>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${playfair.variable} ${cinzel.variable} antialiased`}
       >


### PR DESCRIPTION
## Summary
- Add Google Analytics (gtag.js) to track user behavior

## Changes
- Add `next/script` with `afterInteractive` strategy for optimal performance
- Tracking ID: `G-65HJEVF1M4`