### PR TITLE
feat(#268): display enrichment progress in full_techniques mode

### DIFF
--- a/frontend/src/components/evaluation/FullTechniquesProgress.tsx
+++ b/frontend/src/components/evaluation/FullTechniquesProgress.tsx
@@ -63,19 +63,22 @@ export const FullTechniquesProgress: React.FC<FullTechniquesProgressProps> = ({ 
         etaSeconds={state.etaSeconds}
         totalTechniques={state.totalTechniques}
         completedTechniques={state.completedTechniques}
+        enrichmentMessage={state.enrichmentMessage}
       />
 
       <main className="flex-1 max-w-7xl w-full mx-auto p-4 md:p-6 space-y-8">
         
         <div className="text-center space-y-2 py-4">
           <h1 className="text-3xl md:text-4xl font-serif font-bold text-[#722F37] animate-fade-in">
-            {state.currentStage === 'deep_synthesis' ? 'Synthesizing Insights...' :
+            {state.currentStage === 'enrichment' ? 'Preparing Analysis...' :
+             state.currentStage === 'deep_synthesis' ? 'Synthesizing Insights...' :
              state.currentStage === 'quality_gate' ? 'Final Quality Gate...' :
              state.currentStage === 'complete' ? 'Evaluation Complete' :
              'Tasting Flight in Progress'}
           </h1>
           <p className="text-gray-600 max-w-2xl mx-auto">
-            {state.currentStage === 'deep_synthesis' ? 'Our Master Sommelier is blending the notes from all 75 techniques.' :
+            {state.currentStage === 'enrichment' ? 'Gathering context through code analysis, RAG, and web search.' :
+             state.currentStage === 'deep_synthesis' ? 'Our Master Sommelier is blending the notes from all 75 techniques.' :
              state.currentStage === 'quality_gate' ? 'Verifying final scores and generating the vintage report.' :
              state.currentStage === 'complete' ? 'Your vintage report is ready for review.' :
              'Analyzing your codebase across 8 dimensions and 75 distinct techniques.'}

--- a/frontend/src/components/evaluation/ProgressTopBar.tsx
+++ b/frontend/src/components/evaluation/ProgressTopBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Wifi, WifiOff, Clock, GitBranch } from 'lucide-react';
+import { Wifi, WifiOff, Clock, GitBranch, Loader2 } from 'lucide-react';
 
 interface ProgressTopBarProps {
   repoName: string;
@@ -8,6 +8,7 @@ interface ProgressTopBarProps {
   etaSeconds?: number;
   totalTechniques: number;
   completedTechniques: number;
+  enrichmentMessage?: string | null;
 }
 
 export const ProgressTopBar: React.FC<ProgressTopBarProps> = ({
@@ -17,6 +18,7 @@ export const ProgressTopBar: React.FC<ProgressTopBarProps> = ({
   etaSeconds,
   totalTechniques,
   completedTechniques,
+  enrichmentMessage,
 }) => {
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
@@ -59,6 +61,12 @@ export const ProgressTopBar: React.FC<ProgressTopBarProps> = ({
         </div>
 
         <div className="flex items-center gap-4 text-sm">
+          {enrichmentMessage && (
+            <div className="flex items-center gap-1.5 px-3 py-1 rounded-full bg-amber-500/10 border border-amber-500/20 text-amber-700 text-xs font-medium">
+              <Loader2 size={12} className="animate-spin" />
+              <span className="truncate max-w-[150px]">{enrichmentMessage}</span>
+            </div>
+          )}
           <div className="hidden md:block text-gray-600 font-medium">
             <span className="text-[#722F37] font-bold">{completedTechniques}</span>
             <span className="text-gray-400 mx-1">/</span>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -70,7 +70,10 @@ export type SSEEventType =
   | 'deep_synthesis_start'
   | 'deep_synthesis_complete'
   | 'quality_gate_complete'
-  | 'metrics_update';
+  | 'metrics_update'
+  | 'enrichment_start'
+  | 'enrichment_complete'
+  | 'enrichment_error';
 
 export interface SSEEvent {
   event_type: SSEEventType;


### PR DESCRIPTION
## Summary
Resolves #268

## Problem
In `full_techniques` mode, the backend emits enrichment events (`enrichment_start`, `enrichment_complete`, `enrichment_error`) for three phases: `code_analysis`, `rag`, and `web_search`. However, the frontend **completely ignored these events**, leaving users with no visibility into this critical pre-evaluation phase.

## Changes

### Types (`types/index.ts`)
- Add `enrichment_start`, `enrichment_complete`, `enrichment_error` to `SSEEventType`

### State Management (`useFullTechniquesStream.ts`)
- Add `EnrichmentPhase` and `EnrichmentStepStatus` types
- Add `enrichmentPhase`, `enrichmentMessage`, `enrichmentStatus` to state
- Add `'enrichment'` to `currentStage` union type
- Handle `enrichment_start/complete/error` events in reducer
- Auto-transition from enrichment to categories when first technique starts

### UI (`ProgressTopBar.tsx`, `FullTechniquesProgress.tsx`)
- Add spinner + status message indicator to ProgressTopBar during enrichment
- Add "Preparing Analysis..." stage messaging to FullTechniquesProgress

## Visual Design
During enrichment phase, the ProgressTopBar shows:
```
[⏳ Code analysis starting...] [0/75 techniques] [0:00] [● Live]
```

Status transitions:
- `⏳ Analyzing code...` (code_analysis running)
- `⏳ Building context...` (rag running)
- `⏳ Searching web...` (web_search running)
- *(hidden when all enrichment complete)*

## Testing
- [x] ESLint passes
- [x] TypeScript compilation succeeds
- [x] Next.js build succeeds

## Checklist
- [x] Code follows project conventions
- [x] SSEEventType includes enrichment events
- [x] Reducer handles all enrichment event types
- [x] UI indicator shows during enrichment phase
- [x] Indicator hides after enrichment complete